### PR TITLE
Install the ey_services_setup gem needed by newrelic on deploys

### DIFF
--- a/cookbooks/ey-base/recipes/post_bootstrap.rb
+++ b/cookbooks/ey-base/recipes/post_bootstrap.rb
@@ -1,6 +1,5 @@
 include_recipe "monit"
 include_recipe "collectd"
-#TODOv6 include_recipe "newrelic"
 include_recipe "nodejs::common"
 include_recipe "reboot"
 

--- a/cookbooks/ey-base/recipes/resin_gems.rb
+++ b/cookbooks/ey-base/recipes/resin_gems.rb
@@ -13,6 +13,11 @@ chef_gem "ey_cloud_server" do
   compile_time false
 end
 
+chef_gem "ey_services_setup" do
+  version "0.0.7"
+  compile_time false
+end
+
 ["eybackup", "eyrestore", "ey-snapshots", "ey-snaplock"].each do |executable|
   link "#{bin_path}/#{executable}" do
     to "#{gem_bin_path}/#{executable}"
@@ -29,7 +34,7 @@ directory resin_path do
   action :create
 end
 
-["ruby", "gem", "engineyard-serverside"].each do |executable|
+["ruby", "gem", "engineyard-serverside", "ey-services-setup"].each do |executable|
   link "#{resin_path}/#{executable}" do
     to "#{gem_bin_path}/#{executable}"
   end


### PR DESCRIPTION
The newrelic recipe isn't needed because ruby apps add newrelic in their Gemfile