### PR TITLE
Remove env.custom from passenger5 recipe

### DIFF
--- a/cookbooks/passenger5/files/default/env.custom
+++ b/cookbooks/passenger5/files/default/env.custom
@@ -1,1 +1,0 @@
-#Custom Environment Variables should be added here

--- a/cookbooks/passenger5/recipes/install.rb
+++ b/cookbooks/passenger5/recipes/install.rb
@@ -109,15 +109,6 @@ node.engineyard.apps.each_with_index do |app,index|
               :version => version)
     notifies :run, "execute[reload-monit]", :delayed
   end
-
-  cookbook_file "/data/#{app.name}/shared/config/env.custom" do
-    source "env.custom"
-    owner node["owner_name"]
-    group node["owner_name"]
-    mode 0644
-    backup 0
-    not_if { FileTest.exists?("/data/#{app.name}/shared/config/env.custom") }
-  end
 end
 
 # Render passenger_monitor script


### PR DESCRIPTION
File is managed by `env_vars` recipe