### PR TITLE
Chown database ssl keys after rsync (was reverted unintentionally)

### DIFF
--- a/cookbooks/db-ssl/templates/default/remote_key_copy.sh.erb
+++ b/cookbooks/db-ssl/templates/default/remote_key_copy.sh.erb
@@ -25,6 +25,7 @@ function push_keys {
     rsync -a -e "${ssh_options}" ${keyname}.crt ${target}:${user_home}/.${keyname}/
     rsync -a -e "${ssh_options}" ${keyname}.key ${target}:${user_home}/.${keyname}/
     rsync -a -e "${ssh_options}" root.crt ${target}:${user_home}/.${keyname}/
+    eval ${ssh_options} ${target} "chown ${user}:${user} -R ${user_home}/.${keyname}"
   fi
 }
 


### PR DESCRIPTION
Added in https://github.com/engineyard/ey-cookbooks-dev-v6/commit/f04a41d904c7b87e45d6c18919797bb6ef0feae6#diff-0f49572a1c8fe97e83ad0e77fb35fd14

Reverted unintentionally in https://github.com/engineyard/ey-cookbooks-dev-v6/commit/a7c71678048e27ed691f7dce50d7fdbcf2ebea08#diff-0f49572a1c8fe97e83ad0e77fb35fd14