### PR TITLE
Updated mnml resin

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 ---
-mnml_version: '1.0.2'
+mnml_version: '1.0.3'
 chef_version: '12.22.5'
 enzyme_version: '2.0.6'


### PR DESCRIPTION
This bumps the mnml resin to the latest version which patches Chef to support Rubygems 3.x.