### PR TITLE
Updating reboot script to ensure full Chef run on v6

### DIFF
--- a/cookbooks/mysql/recipes/extras.rb
+++ b/cookbooks/mysql/recipes/extras.rb
@@ -1,9 +1,9 @@
 # Installs extra packages
 #
 # Timezone tables
-tz_tables_loaded = %Q{mysql -u #{node.engineyard.environment['db_admin_username']} -N -e 'SELECT COUNT(*)>0 FROM mysql.time_zone' | grep 1}
+tz_tables_loaded = %Q{mysql -u #{node.engineyard.environment['db_admin_username']} -p'#{node.engineyard.environment['db_admin_password']}' -N -e 'SELECT COUNT(*)>0 FROM mysql.time_zone' | grep 1}
 
 execute "load-tz-tables" do
-  command "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u #{node.engineyard.environment['db_admin_username']} mysql"
+  command "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u #{node.engineyard.environment['db_admin_username']} -p'#{node.engineyard.environment['db_admin_password']}' mysql"
   not_if tz_tables_loaded
 end

--- a/cookbooks/postgresql/recipes/setup_app_users_dbs.rb
+++ b/cookbooks/postgresql/recipes/setup_app_users_dbs.rb
@@ -2,26 +2,31 @@
 admin_username = node.engineyard.environment['db_admin_username']
 admin_password = node.engineyard.environment['db_admin_password']
 
+if ['solo', 'db_master', 'eylocal'].include?(node.dna[:instance_role])
+  db_hostname = "localhost"
+else
+  db_hostname = node.dna['db_host']
+end
 
 node.engineyard.apps.each do |app|
   execute "create db user #{app.database_username}" do
-    command  %{psql -U #{admin_username} -h #{node['dna']['db_host']} -c "CREATE USER #{app.database_username} with ENCRYPTED PASSWORD '#{app.database_password}' createdb" postgres}
-    not_if %{psql -U #{admin_username} -h #{node['dna']['db_host']} -c "select * from pg_roles" postgres | grep #{app.database_username}}
+    command  %{psql -U #{admin_username} -h #{db_hostname} -c "CREATE USER #{app.database_username} with ENCRYPTED PASSWORD '#{app.database_password}' createdb" postgres}
+    not_if %{psql -U #{admin_username} -h #{db_hostname} -c "select * from pg_roles" postgres | grep #{app.database_username}}
   end
 
   if db_host_is_rds?
     execute "grant db user role #{app.database_username} to admin user #{admin_username}" do
-      command %{psql -U #{admin_username} -h #{node['dna']['db_host']} -c "GRANT #{app.database_username} TO #{admin_username} WITH ADMIN OPTION;" postgres}
+      command %{psql -U #{admin_username} -h #{db_hostname} -c "GRANT #{app.database_username} TO #{admin_username} WITH ADMIN OPTION;" postgres}
     end
   end
 
   execute "create database for #{app.database_name} owned by #{app.database_username}" do
-    command %{PGPASSWORD="#{app.database_password}" createdb -U #{app.database_username} -h #{node['dna']['db_host']} #{app.database_name}}
-    not_if %{psql -U #{admin_username}  -h #{node['dna']['db_host']} -t -c "select datname from pg_database where datname = '#{app.database_name}';" postgres | grep #{app.database_name}}
+    command %{PGPASSWORD="#{app.database_password}" createdb -U #{app.database_username} -h #{db_hostname} #{app.database_name}}
+    not_if %{psql -U #{admin_username}  -h #{db_hostname} -t -c "select datname from pg_database where datname = '#{app.database_name}';" postgres | grep #{app.database_name}}
   end
 
   execute "alter public schema of db #{app.database_name} owner to #{app.database_username}" do
-    command %{psql -U #{admin_username}  -h #{node['dna']['db_host']} -c "ALTER SCHEMA public OWNER TO #{app.database_username}" #{app.database_name}}
-    not_if %{psql -U #{admin_username}  -h #{node['dna']['db_host']} -c "select pg_is_in_recovery()" | grep t}
+    command %{psql -U #{admin_username}  -h #{db_hostname} -c "ALTER SCHEMA public OWNER TO #{app.database_username}" #{app.database_name}}
+    not_if %{psql -U #{admin_username}  -h #{db_hostname} -c "select pg_is_in_recovery()" | grep t}
   end
 end

--- a/cookbooks/reboot/templates/default/rc.local.erb
+++ b/cookbooks/reboot/templates/default/rc.local.erb
@@ -10,8 +10,7 @@ else
   if [ -f /etc/chef/recipes/cookbooks/ey-init/recipes/main.rb ]
   then
     LOG_TIME=`date +'%Y-%m-%dT%H-%M-%S'`
-    sed -e "s/chef.*log\"/chef.$LOG_TIME.log\"/" -i /etc/chef/solo.rb
-    sed -e 's/"quick": true/"full_run": true/' -i /etc/chef/dna.json
-    /opt/chef/bin/chef-solo -j /etc/chef/dna.json -c /etc/chef/solo.rb 
+    sed -e "s/var\/log\/chef.*\"/var\/log\/chef.$LOG_TIME.log\"/" -i /etc/chef/solo.rb
+    /opt/chef/embedded/bin/ey-enzyme --refresh-dna --cached --run-list ey-init::main --chef-bin /opt/chef/embedded/bin/chef-solo
   fi
 fi


### PR DESCRIPTION
Updates the rc.local script to ensure v6 instances do a full Chef run, in response to missing /var/run/engineyard preventing Unicorn starting up if an instance is restarted multiple times consecutively.
Also updates MySQL extras recipe to use password as former no password method fails on post restart run.
Also updates PostgreSQL setup_app_users_dbs recipe to use localhost for the DB hostname on instances running DBs, as hostname from DNA does not yet resolve to updated private IP that soon after instance restart and thus access is blocked by AWS SG. On other instances it still resolves to host from DNA in order that it works with RDS still.
Some QA already done, tested on solo (both EIP and public hostname) and multi instance environments, with Unicorn and Passenger and latest MySQL and PostgreSQL versions, restarting solo, app master and db master instances and ensuring Chef runs cleanly and application comes back online without manual intervention.