### PR TITLE
Always create env.custom, even an empty one

### DIFF
--- a/cookbooks/app/recipes/create.rb
+++ b/cookbooks/app/recipes/create.rb
@@ -70,5 +70,6 @@ end
 
 end
 
+include_recipe "env_vars::init"
 include_recipe "env_vars::cloud"
 include_recipe "cdn_distribution::default"

--- a/cookbooks/app/recipes/create.rb
+++ b/cookbooks/app/recipes/create.rb
@@ -70,10 +70,6 @@ end
 
 end
 
-<<<<<<< HEAD
 include_recipe "env_vars::init"
-=======
-include_recipe "env_vars"
->>>>>>> e9e0ae0548935374e355d877e0f7793ec1c45dae
 include_recipe "env_vars::cloud"
 include_recipe "cdn_distribution::default"

--- a/cookbooks/env_vars/recipes/init.rb
+++ b/cookbooks/env_vars/recipes/init.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: env_vars
+# Recipe:: init
+#
+
+if ['solo', 'app', 'app_master', 'util'].include?(node['dna']['instance_role'])
+
+  ssh_username = node['dna']['engineyard']['environment']['ssh_username']
+
+  node['dna']['applications'].each do |app_name, data|
+    template "/data/#{app_name}/shared/config/env.custom" do
+      source "env.custom.erb"
+      owner ssh_username
+      group ssh_username
+      mode 0744
+      not_if { File.exists?("/data/#{app_name}/shared/config/env.custom")}
+
+    end
+  end
+
+end


### PR DESCRIPTION
#### Description of your patch
Adding an empty env.custom file when no recipe custom-env_vars is not used

#### Recommended Release Notes
Adds an empty env.custom file in cases where no custom variables are set

#### Estimated risk
Low

#### Components involved
Unicorn

#### Description of testing done
See QA instructions

#### QA Instructions
Boot env with QA stack.
Make sure that there are no chef/deploy errors
Add env variables through dashboard. Make sure that they are added successfully.
Use custom-env_vars recipe to add custom variables. Make sure that they are added successfully.