### PR TITLE
Check if bin/ruby exists instead of ruby -v

### DIFF
--- a/cookbooks/ruby/recipes/default.rb
+++ b/cookbooks/ruby/recipes/default.rb
@@ -42,9 +42,7 @@ include_recipe "ruby::dependencies"
 
 bash "install ruby" do
   code <<-EOH
-    source /usr/local/share/chruby/chruby.sh
-    chruby #{ruby_version}
-    if [ "$(ruby -v | grep #{ruby_version})" ]
+    if [ -e /opt/rubies/ruby-#{ruby_version}/bin/ruby ]
     then
       echo "Ruby #{ruby_version} is already installed. Skipping Ruby installation"
     else


### PR DESCRIPTION
Fixes issues with preview versions like 2.7.0-preview1. Prevents installing ruby if it's already installed.