### PR TITLE
[FB-493] Update Ruby versions

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -132,15 +132,12 @@ class Chef
       end
 
       def default_ruby_version(ruby_archtype)
-        # According to https://support.cloud.engineyard.com/hc/en-us/articles/222896468
-        #and:
-        # https://github.com/engineyard/awsm/blob/0accca6f3695b700524f0fff62e3d79375fdb580/lib/awsm/component_version.rb#L21
+        # According to https://support.cloud.engineyard.com/hc/en-us/articles/360022162773-Engine-Yard-Ubuntu-19-05-Technology-Stack
         versions = {
-          :ruby_220   => "2.2.10",
           :ruby_230   => "2.3.8",
-          :ruby_240   => "2.4.5",
-          :ruby_250   => "2.5.3",
-          :ruby_260   => "2.6.1"
+          :ruby_240   => "2.4.6",
+          :ruby_250   => "2.5.5",
+          :ruby_260   => "2.6.3"
         }
         if versions.has_key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]


### PR DESCRIPTION
Description of your patch
-------------
Update the patch versions of the supported Rubies.

Recommended Release Notes
-------------
Make the latest Ruby versions available.

Estimated risk
-------------
Medium. Only the patch versions of Ruby got bumped.

Components involved
-------------
ey-environment library: `default_ruby_version` function

Description of testing done
-------------
Booted an environment with the following Ruby versions (sequentially) 2.3, 2.4, 2.5, 2.6.
Checked if it booted and applied correctly and deployed successfully.
Checked if the correct (and latest) ruby version got installed and used.

QA Instructions
-------------
N/A