### PR TITLE
Add /root/.gemrc with --no-document

### DIFF
--- a/cookbooks/passenger5/recipes/install.rb
+++ b/cookbooks/passenger5/recipes/install.rb
@@ -12,7 +12,7 @@ end
 # Install gems required by Passenger standalone
 ruby_block "gems to install" do
   block do
-    system("gem install daemon_controller rack:1.6.4 --no-ri --no-rdoc")
+    system("gem install daemon_controller rack:1.6.4")
   end
 end
 

--- a/cookbooks/ruby/files/default/gemrc
+++ b/cookbooks/ruby/files/default/gemrc
@@ -1,0 +1,2 @@
+---
+gem: --no-ri --no-rdoc --no-document

--- a/cookbooks/ruby/files/default/gemrc
+++ b/cookbooks/ruby/files/default/gemrc
@@ -1,2 +1,2 @@
 ---
-gem: --no-ri --no-rdoc --no-document
+gem: --no-document

--- a/cookbooks/ruby/recipes/default.rb
+++ b/cookbooks/ruby/recipes/default.rb
@@ -64,4 +64,9 @@ ruby_block "add ruby path during chef run" do
   block { ENV['PATH'] = "/opt/rubies/ruby-#{ruby_version}/bin:#{ENV['PATH']}" }
 end
 
+# Add gemrc for the root user
+cookbook_file "/root/.gemrc" do
+  source "gemrc"
+end
+
 include_recipe "ruby::rubygems"

--- a/cookbooks/ruby/recipes/rubygems.rb
+++ b/cookbooks/ruby/recipes/rubygems.rb
@@ -22,7 +22,7 @@ def ensure_rubygems_version
     end
 
     execute "install rubygems #{rubygems}" do
-      command "gem install rubygems-update -v #{rubygems} --no-ri --no-rdoc"
+      command "gem install rubygems-update -v #{rubygems}"
     end
 
     bash "update rubygems to >= #{rubygems}" do


### PR DESCRIPTION
Remove --no-ri --no-rdoc from recipes

Here's the description from the v5 PR
> Remove --no-ri --no-rdoc
> Add /root/.gemrc with --no-ri --no-rdoc --no-document
> Note: .gemrc having --no-ri --no-rdoc on rubgyems 3 and --no-document on rubygems 2 is not a > problem. gem commands won't fail. gem install will only fail with --no-ri --no-rdoc on rubygems 3 > if you use the flags on the command line NOT on .gemrc

https://github.com/engineyard/ey-cookbooks-stable-v5/pull/398