### PR TITLE
[FB-552] Add ignore logic to check_readonly script

### DIFF
--- a/cookbooks/collectd/files/default/mounts_ro_ignore
+++ b/cookbooks/collectd/files/default/mounts_ro_ignore
@@ -1,0 +1,5 @@
+/snap
+/run/user
+/proc
+/sys
+/sys/fs/cgroup

--- a/cookbooks/collectd/recipes/default.rb
+++ b/cookbooks/collectd/recipes/default.rb
@@ -122,6 +122,14 @@ cookbook_file "/etc/engineyard/fs_type_check_ignore" do
   not_if { File.exist?('/etc/engineyard/fs_type_check_ignore')}
 end
 
+cookbook_file "/etc/engineyard/mounts_ro_ignore" do
+  source "mounts_ro_ignore"
+  owner node["owner_name"]
+  group node["owner_name"]
+  mode 0755
+  not_if { File.exist?('/etc/engineyard/mounts_ro_ignore')}
+end
+
 cookbook_file "/etc/systemd/system/collectd.service" do
   source "collectd.service"
   owner "root"


### PR DESCRIPTION
Description of your patch
-------------
This PR fixes alerts with the message "The device mounted at /snap/core/7270 is read only".
It does so by defining file-system mountpoint patterns that should be ignored by this check.
Those patterns currently are:
```
/snap
/run/user
/proc
/sys
```
If a mountpoint (e.g. `/snap/core/7270`) is read-only, but matches one of the patterns, it is not reported.

Recommended Release Notes
-------------
Fix false read-only mounts alerts.

Estimated risk
-------------
Medium. Only the `check_readonly.sh` script has been changed. We need to make sure though, that no "real" alerts will be ignored.

Components involved
-------------
collect recipe - `check_readonly.sh` script

Description of testing done
-------------
1. Booted a solo env (Ruby app, testing stack with this PR).
2. Checked if deploy succeeds and app works.
3. Verified that no false read-only alerts show up.
4. Stopped the database server and remounted `/db` as read-only (`mount -o remount,ro  /db`).
5. Verified that a read-only alert for `/db` is shown.
6. Remounted `/db` to read-write (`mount -o remount,rw  /db`).
7. Verified that the alert cleared up.

QA Instructions
-------------
Test with a PHP app.
Test with different environment configurations (staging, production, custom blueprint).