### PR TITLE
[FB-576] Assume HTTP 401 as healthy on HAproxy healthcheck

### DIFF
--- a/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -128,7 +128,7 @@ backend egress_80
 <% else -%>
   option httpchk HEAD / HTTP/1.1\r\nHost:\ _
 <% end -%>
-  http-check expect rstatus ((2|3)[0-9][0-9]|503)
+  http-check expect rstatus ((2|3)[0-9][0-9]|503|401)
 
 <% if @backends.any? %>
   <% @backends.each_with_index do |instance, i| %>
@@ -143,7 +143,7 @@ backend egress_443
   mode tcp
 <% if @httpchk_path -%>
   option httpchk HEAD <%= @httpchk_path %><% if @httpchk_host %> HTTP/1.1\r\nHost:\ <%= @httpchk_host %><% end %>
-  http-check expect rstatus ((2|3)[0-9][0-9]|503)
+  http-check expect rstatus ((2|3)[0-9][0-9]|503|401)
 <% else -%>
   option tcp-check
 <% end -%>


### PR DESCRIPTION
#### Description of your patch
Assume HTTP 401 as healthy on HAproxy healthcheck 

#### Recommended Release Notes
HAproxy is now accepting HTTP 401 return as a healthy check

#### Estimated risk
Low

#### Components involved
HAproxy

#### Description of testing done
See QA instructions

#### QA Instructions
Boot environment
Deploy TODO app and use basic authentication (https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basic-authentication/)
Verify that HTTP 401s are returned from nginx to HAproxy and that HAproxy is marking app instances as healthy
