### PR TITLE
Postgresql upgrade 10.9 and 11.4

### DIFF
--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -6,10 +6,10 @@ when "postgres9_6"
   default['postgresql']['latest_version'] = '9.6.13'
   default['postgresql']['short_version'] = '9.6'
 when "postgres10"
-  default['postgresql']['latest_version'] = '10.8'
+  default['postgresql']['latest_version'] = '10.9'
   default['postgresql']['short_version'] = '10'
 when "postgres11"
-  default['postgresql']['latest_version'] = '11.3'
+  default['postgresql']['latest_version'] = '11.4'
   default['postgresql']['short_version'] = '11'
 end
 default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -3,8 +3,8 @@ install_version = node['postgresql']['latest_version']
 known_versions = %w[
   9.5.17
   9.6.13
-  10.7 10.8
-  11.3
+  10.7 10.8 10.9
+  11.3 11.4
 ]
 package_version = known_versions.detect {|v| v =~ /^#{install_version}/}
 

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -50,6 +50,12 @@ package "postgresql-client-common"
 package "libpq-dev"
 package "libpq5"
 
+if postgres_version == "11"
+  package "libllvm6.0"
+  package "clang-6.0"
+  package "llvm-6.0-dev"
+end
+
 # This ruby block handles if the lock version file is set
 # It needs to be done like this since the file isn't present during the compile
 # phase on first runs on new instances booted from snapshots

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -47,8 +47,6 @@ end
 # install postgresql dependencies
 package "postgresql-common"
 package "postgresql-client-common"
-package "libpq-dev"
-package "libpq5"
 
 if postgres_version == "11"
   package "libllvm6.0"

--- a/cookbooks/postgresql/templates/default/install.sh.erb
+++ b/cookbooks/postgresql/templates/default/install.sh.erb
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 mkdir -p /tmp/src/postgresql
-<% packages = ["postgresql-client-#{@postgres_version}", "postgresql-#{@postgres_version}", "postgresql-server-dev-#{@postgres_version}"] %>
+
+<% packages = ["libpq5", "libpq-dev", "postgresql-client-#{@postgres_version}", "postgresql-#{@postgres_version}", "postgresql-server-dev-#{@postgres_version}"] %>
 <% packages.each do |package| %>
 installed=$(apt-cache policy <%= package %> | grep -E "Installed.*<%= @package_version %>-" > /dev/null)
 if [ $? -ne 0 ]; then

--- a/cookbooks/postgresql/templates/default/install.sh.erb
+++ b/cookbooks/postgresql/templates/default/install.sh.erb
@@ -1,8 +1,37 @@
 #!/bin/bash
 
 mkdir -p /tmp/src/postgresql
+<% packages = ["libpq5", "libpq-dev"] %>
+<% packages.each do |package| %>
+installed=$(apt-cache policy <%= package %> | grep -E "Installed.*<%= @package_version %>-" > /dev/null)
+if [ $? -ne 0 ]; then
+  echo "Installing <%= package %>"
+  cd /tmp/src/postgresql
+  <% if @postgres_version.to_i == 11 %>
+    <%# https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-11/libpq5_11.4-1.pgdg18.04%2b1_amd64.deb %>
+    url=https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-<%= @postgres_version %>/<%= package %>_<%= @package_version %>-1.pgdg18.04+1_amd64.deb
+  <% elsif [9, 10].include?(@postgres_version.to_i) %>
+    <%# https://apt.postgresql.org/pub/repos/apt/pool/10/p/postgresql-10/libpq5_10.9-1.pgdg18.04%2b1_amd64.deb %>
+    url=https://apt.postgresql.org/pub/repos/apt/pool/<%= @postgres_version %>/p/postgresql-<%= @postgres_version %>/<%= package %>_<%= @package_version %>-1.pgdg18.04+1_amd64.deb
+  <% end %>
+  available=$(curl -s -I $url | head -n 1 | grep 200)
+  if [ $? -eq 0 ]; then
+    curl -s -O $url
+  fi
 
-<% packages = ["libpq5", "libpq-dev", "postgresql-client-#{@postgres_version}", "postgresql-#{@postgres_version}", "postgresql-server-dev-#{@postgres_version}"] %>
+  available=$(curl -s -I https://atalia.postgresql.org/morgue/p/postgresql-<%= @postgres_version %>/<%= package %>_<%= @package_version %>-1.pgdg18.04+1_amd64.deb | head -n 1 | grep 200)
+  if [ $? -eq 0 ]; then
+    curl -s -O https://atalia.postgresql.org/morgue/p/postgresql-<%= @postgres_version %>/<%= package %>_<%= @package_version %>-1.pgdg18.04+1_amd64.deb
+  fi
+
+  DEBIAN_FRONTEND=noninteractive dpkg -i /tmp/src/postgresql/<%= package %>_<%= @package_version %>-1.pgdg18.04+1_amd64.deb
+else
+  echo '<%= package %> <%= @package_version %> is already installed'
+fi
+
+<% end %>
+
+<% packages = ["postgresql-client-#{@postgres_version}", "postgresql-#{@postgres_version}", "postgresql-server-dev-#{@postgres_version}"] %>
 <% packages.each do |package| %>
 installed=$(apt-cache policy <%= package %> | grep -E "Installed.*<%= @package_version %>-" > /dev/null)
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
#### Description of your patch
Install Postgresql 11 dependencies
Install libpq5 and libpq-dev using .deb files
Upgrade Postgresql to 10.9 and 11.4

#### Recommended Release Notes
Upgrade Postgresql to 10.9 and 11.4

#### Estimated risk
High

#### Components involved
Postgresql

#### Description of testing done
See QA instructions

#### QA Instructions
1. Boot an environment with Postgresql 10. Check that Postgresql 10.9 is running.
2. Boot an environment with Postgresql 11. Check that Postgresql 11.4 is running.

Note: If you're upgrading an existing environment or booting an environment using a snapshot, make sure "Prevent database version changes" is not checked to get the latest versions.
