### PR TITLE
Use apt install and Upgrade Postgresql

### DIFF
--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -6,10 +6,10 @@ when "postgres9_6"
   default['postgresql']['latest_version'] = '9.6.13'
   default['postgresql']['short_version'] = '9.6'
 when "postgres10"
-  default['postgresql']['latest_version'] = '10.8'
+  default['postgresql']['latest_version'] = '10.9'
   default['postgresql']['short_version'] = '10'
 when "postgres11"
-  default['postgresql']['latest_version'] = '11.3'
+  default['postgresql']['latest_version'] = '11.4'
   default['postgresql']['short_version'] = '11'
 end
 default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -3,8 +3,8 @@ install_version = node['postgresql']['latest_version']
 known_versions = %w[
   9.5.17
   9.6.13
-  10.7 10.8
-  11.3
+  10.7 10.8 10.9
+  11.3 11.4
 ]
 package_version = known_versions.detect {|v| v =~ /^#{install_version}/}
 

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -44,12 +44,6 @@ directory "/tmp/src/postgresql" do
   recursive true
 end
 
-# install postgresql dependencies
-package "postgresql-common"
-package "postgresql-client-common"
-package "libpq-dev"
-package "libpq5"
-
 # This ruby block handles if the lock version file is set
 # It needs to be done like this since the file isn't present during the compile
 # phase on first runs on new instances booted from snapshots

--- a/cookbooks/postgresql/templates/default/install.sh.erb
+++ b/cookbooks/postgresql/templates/default/install.sh.erb
@@ -17,7 +17,7 @@ if [ $? -ne 0 ]; then
     curl -s -O https://atalia.postgresql.org/morgue/p/postgresql-<%= @postgres_version %>/<%= package %>_<%= @package_version %>-1.pgdg18.04+1_amd64.deb
   fi
 
-  DEBIAN_FRONTEND=noninteractive dpkg -i /tmp/src/postgresql/<%= package %>_<%= @package_version %>-1.pgdg18.04+1_amd64.deb
+  DEBIAN_FRONTEND=noninteractive apt install -y --allow-downgrades /tmp/src/postgresql/<%= package %>_<%= @package_version %>-1.pgdg18.04+1_amd64.deb
   <% if package=="postgresql-#{@postgres_version}" %>
   if [[ ! -n $(systemctl status postgresql | grep "Loaded.*/etc/systemd/system/postgresql.service") ]]; then
     systemctl stop postgresql && rm -f /lib/systemd/system/postgresql.service


### PR DESCRIPTION
#### Description of your patch
Use apt install to install .deb files
Upgrade Postgresql to 10.9 and 11.4

#### Recommended Release Notes
Upgrade Postgresql to 10.9 and 11.4

#### Estimated risk
High

#### Components involved
Postgresql

#### Description of testing done
See QA instructions

#### QA Instructions
1. Boot an environment with Postgresql 10. Check that Postgresql 10.9 is running.
2. Boot an environment with Postgresql 11. Check that Postgresql 11.4 is running.

Note: If you're upgrading an existing environment or booting an environment using a snapshot, make sure "Prevent database version changes" is not checked to get the latest versions.
