### PR TITLE
[FB-635] Add allow_downgrades to packages recipe

### DIFF
--- a/cookbooks/packages/recipes/default.rb
+++ b/cookbooks/packages/recipes/default.rb
@@ -30,6 +30,7 @@ install.each do |package|
   package package['name'] do
     version package['version']
     action :install
+    options '--allow-downgrades' if package['allow_downgrades']
   end
 
 end

--- a/custom-cookbooks/packages/cookbooks/custom-packages/attributes/default.rb
+++ b/custom-cookbooks/packages/cookbooks/custom-packages/attributes/default.rb
@@ -7,6 +7,11 @@ default['packages'].tap do |packages|
   packages['install'] = [
     {'name' => "sphinxsearch", 'version' => "2.2.11-2"},
     {'name' => "wkhtmltopdf"}
+
+    # if you want to install an older version of a package, use allow_downgrades
+    # in most cases, we recommend you skip the version to install the latest version
+    # install an older version of a package only if you really need that specific version
+    # {'name' => 'imagemagick', 'version' => '8:6.9.7.4+dfsg-16ubuntu6', 'allow_downgrades' => true}
   ]
 end
 


### PR DESCRIPTION
#### Description of your patch
Add allow_downgrades to packages recipe
https://t3.fogbugz.com/f/cases/635

#### Recommended Release Notes
Add allow_downgrades to packages recipe to install old versions of packages

#### Estimated risk
Low

#### Components involved
Packages custom recipe

#### Description of testing done
See QA instructions

#### QA Instructions
Install the latest imagemagick package (apt-get install imagemagick)
Enable custom packages recipe.
Add `{'name' => 'imagemagick', 'version' => '8:6.9.7.4+dfsg-16ubuntu6', 'allow_downgrades' => true}` to custom-packages/attributes/default.rb
Check that imagemagick is downgraded.