### PR TITLE
[FB-741] Bump PostgreSQL 9.5 and 9.6 versions

### DIFF
--- a/cookbooks/postgresql/attributes/version.rb
+++ b/cookbooks/postgresql/attributes/version.rb
@@ -1,9 +1,9 @@
 case attribute['dna']['engineyard']['environment']['db_stack_name']
 when "postgres9_5"
-  default['postgresql']['latest_version'] = '9.5.17'
+  default['postgresql']['latest_version'] = '9.5.18'
   default['postgresql']['short_version'] = '9.5'
 when "postgres9_6"
-  default['postgresql']['latest_version'] = '9.6.13'
+  default['postgresql']['latest_version'] = '9.6.14'
   default['postgresql']['short_version'] = '9.6'
 when "postgres10"
   default['postgresql']['latest_version'] = '10.9'

--- a/cookbooks/postgresql/recipes/server_install.rb
+++ b/cookbooks/postgresql/recipes/server_install.rb
@@ -1,8 +1,8 @@
 postgres_version = node['postgresql']['short_version']
 install_version = node['postgresql']['latest_version']
 known_versions = %w[
-  9.5.17
-  9.6.13
+  9.5.17 9.5.18
+  9.6.13 9.6.14
   10.7 10.8 10.9
   11.3 11.4
 ]


### PR DESCRIPTION
Description of your patch
-------------
Update to the latest available patch versions of PostgreSQL 9.5 and 9.6.

Recommended Release Notes
-------------
Upgrade to PostgreSQL 9.5.18 and 9.6.14.

Estimated risk
-------------
Low. These are just patch version bumps.

Components involved
-------------
postgresql cookbook.

Description of testing done
-------------
0. Created a testing stack with the changes of this PR.
1. Created, Booted, and deployed Ruby environments (solo, PG 9.5 and staging, PG 9.6)
2. Verified if the app work.
3. Verified if the installed PostgreSQL versions are 9.5.18 and 9.6.14 respectively.

QA Instructions
-------------
Test patch version upgrades and downgrades of PG 9.5 and 9.6.
Test different environment configurations.