### PR TITLE
Fixes Resque Ruby Location For Bundler

### DIFF
--- a/cookbooks/resque/files/default/resque
+++ b/cookbooks/resque/files/default/resque
@@ -4,7 +4,9 @@
 
 original_path="$PWD"
 
-PATH=/bin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:$PATH
+ruby_loc="$(which ruby |sed -e 's/\(\/ruby\)*$//g')"
+
+PATH=/bin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:$ruby_loc:$PATH
 
 usage() {
   echo -e "


### PR DESCRIPTION
Description of your patch
-------------
Fix path location for ruby in resque script

Recommended Release Notes
-------------
Fix path location for ruby in resque script
Issue #123 

Estimated risk
-------------
Low

Components involved
-------------
Chef
resque recipe

Description of testing done
-------------
Created a v6 environment ran resque script made sure bundler location was found.
Edited script and printed out $PATH to show the location was correct

QA Instructions
-------------
Boot up an environment with the custom resque chef recipe and an application which uses resque, check that resque is running in processes and under monit