### PR TITLE
Enable fcgiwrap.socket on instance start.

### DIFF
--- a/cookbooks/collectd/recipes/httpd.rb
+++ b/cookbooks/collectd/recipes/httpd.rb
@@ -48,6 +48,11 @@ cookbook_file "/etc/systemd/system/fcgiwrap.service.d/override.conf" do
   notifies :restart, "service[fcgiwrap]", :delayed
 end
 
+service 'fcgiwrap.socket' do
+  provider Chef::Provider::Service::Systemd
+  action :enable
+end
+
 service "collectd-httpd" do
   provider Chef::Provider::Service::Systemd
   action :nothing


### PR DESCRIPTION
#### Description of your patch
Enable fcgiwrap.socket on instance start.

#### Recommended Release Notes
Fixes performance graphs' unavailability after instance reboot

#### Estimated risk
Low

#### Components involved
Collectd

#### Description of testing done
See QA instructions

#### QA Instructions
Boot QA stack using all type of instance (app_master + app + db_master + db_slave + util)
Verify that performance graphs are available for any instance
Restart each one via dashboard
Clear cookies & cache on browser
Visit performance graphs page for each instance, verify that no error occurs
Log into each instance, run `systemctl status fcgiwrap`, confirm status is `active (running)`