### PR TITLE
Adding shared_db custom recipe

### DIFF
--- a/custom-cookbooks/shared_db/README.md
+++ b/custom-cookbooks/shared_db/README.md
@@ -1,0 +1,5 @@
+# packages
+
+This example contains a complete `cookbooks/` directory that you can use on the stable-v6 stack to use the `database.yml` file of one application on another one.
+
+See [cookbooks/shared_db](cookbooks/shared_db/README.md) for complete instructions.

--- a/custom-cookbooks/shared_db/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/shared_db/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name "ey-custom"
+
+depends "shared_db"

--- a/custom-cookbooks/shared_db/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/shared_db/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe "shared_db"

--- a/custom-cookbooks/shared_db/cookbooks/shared_db/README.md
+++ b/custom-cookbooks/shared_db/cookbooks/shared_db/README.md
@@ -1,0 +1,46 @@
+## shared_db
+
+This recipe symlinks the `database.yml` file from one application to another in a multiple-application environment.
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+To use the `shared_db` recipe, you should copy this recipe, `shared_db`.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+  ```
+  include_recipe 'shared_db'
+  ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+  ```
+  depends 'shared_db'
+  ```
+
+3. Copy `custom-cookbooks/shared_db/cookbooks/shared_db` to `cookbooks/`
+
+  ```
+  cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+  git clone https://github.com/engineyard/ey-cookbooks-stable-v6
+  cd ey-cookbooks-stable-v6
+  cp custom-cookbooks/shared_db/cookbooks/shared_db /path/to/app/cookbooks/
+  ```
+
+4. Download the ey-core gem on your local machine and upload the recipes
+
+  ```
+  gem install ey-core
+  ey-core recipes upload --environment=<nameofenvironment> --file=<pathtocookbooksfolder> --apply
+  ```
+
+## Customizations
+
+All customizations go to `cookbooks/shared_db/attributes/default.rb`.
+
+### Applications involved
+
+Modify the `app` and `parent_app` variables accordingly. `app` is an array of applications that you wish to write the shared database configuration to while `parent_app` is the name of the application with db credentials you want to use.

--- a/custom-cookbooks/shared_db/cookbooks/shared_db/attributes/default.rb
+++ b/custom-cookbooks/shared_db/cookbooks/shared_db/attributes/default.rb
@@ -1,0 +1,5 @@
+# Array of applications that you wish to write the shared database configuration to
+default['shared_db']['apps'] = ["todo_V6_second"]
+
+# The name of the application with db credentials you want to use
+default['shared_db']['parent_app'] = "todo"

--- a/custom-cookbooks/shared_db/cookbooks/shared_db/metadata.rb
+++ b/custom-cookbooks/shared_db/cookbooks/shared_db/metadata.rb
@@ -1,0 +1,6 @@
+description 'Symlink the database.yml file from one app to another'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'info@engineyard.com'
+version '0.0.1'
+name 'shared_db'

--- a/custom-cookbooks/shared_db/cookbooks/shared_db/recipes/default.rb
+++ b/custom-cookbooks/shared_db/cookbooks/shared_db/recipes/default.rb
@@ -18,6 +18,6 @@ if apps && parent_app
 	execute "Symlink #{parent_app_path} to /data/#{app}/shared/config/database.yml" do
       command "ln -sf #{parent_app_path} /data/#{app}/shared/config/database.yml"
       only_if "test -f #{parent_app_path}"
-	end
+    end
   end
 end

--- a/custom-cookbooks/shared_db/cookbooks/shared_db/recipes/default.rb
+++ b/custom-cookbooks/shared_db/cookbooks/shared_db/recipes/default.rb
@@ -15,7 +15,7 @@ if apps && parent_app
       mode '0755'
       action :create
     end
-	execute "Symlink #{parent_app_path} to /data/#{app}/shared/config/database.yml" do
+    execute "Symlink #{parent_app_path} to /data/#{app}/shared/config/database.yml" do
       command "ln -sf #{parent_app_path} /data/#{app}/shared/config/database.yml"
       only_if "test -f #{parent_app_path}"
     end

--- a/custom-cookbooks/shared_db/cookbooks/shared_db/recipes/default.rb
+++ b/custom-cookbooks/shared_db/cookbooks/shared_db/recipes/default.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: shared_db
+# Recipe:: default
+#
+
+apps = node['shared_db']['apps']
+parent_app = node['shared_db']['parent_app']
+parent_app_path = "/data/#{parent_app}/shared/config/database.yml"
+
+if apps && parent_app
+  for app in apps
+	      file "/data/#{app}/shared/config/keep.database.yml" do
+      			owner 'root'
+      			group 'root'
+      			mode '0755'
+      			action :create
+    		end
+		execute "Symlink #{parent_app_path} to /data/#{app}/shared/config/database.yml" do
+			command "ln -sf #{parent_app_path} /data/#{app}/shared/config/database.yml"
+			only_if "test -f #{parent_app_path}"
+		end
+	end
+end

--- a/custom-cookbooks/shared_db/cookbooks/shared_db/recipes/default.rb
+++ b/custom-cookbooks/shared_db/cookbooks/shared_db/recipes/default.rb
@@ -9,15 +9,15 @@ parent_app_path = "/data/#{parent_app}/shared/config/database.yml"
 
 if apps && parent_app
   for app in apps
-	      file "/data/#{app}/shared/config/keep.database.yml" do
-      			owner 'root'
-      			group 'root'
-      			mode '0755'
-      			action :create
-    		end
-		execute "Symlink #{parent_app_path} to /data/#{app}/shared/config/database.yml" do
-			command "ln -sf #{parent_app_path} /data/#{app}/shared/config/database.yml"
-			only_if "test -f #{parent_app_path}"
-		end
+    file "/data/#{app}/shared/config/keep.database.yml" do
+      owner 'root'
+      group 'root'
+      mode '0755'
+      action :create
+    end
+	execute "Symlink #{parent_app_path} to /data/#{app}/shared/config/database.yml" do
+      command "ln -sf #{parent_app_path} /data/#{app}/shared/config/database.yml"
+      only_if "test -f #{parent_app_path}"
 	end
+  end
 end


### PR DESCRIPTION
#### Description of your patch
Adds `shared_db` custom recipe

#### Recommended Release Notes
Adds shared_db recipe to allow two applications to share a single database.yml configuration file

#### Estimated risk
Low

#### Components involved
New recipe

#### Description of testing done
See QA instructions

#### QA Instructions
Boot QA stack
Add a second application on the QA environment
Enable recipe
Verify that keep.database.yml file is created and each app's database.yml is a sym link to parent app's database.yml