### PR TITLE
[FB-1352] Add -d on read

### DIFF
--- a/cookbooks/mysql/templates/default/check_mysql.sh.erb
+++ b/cookbooks/mysql/templates/default/check_mysql.sh.erb
@@ -106,7 +106,7 @@ function check_replication {
     
     query_db "show slave status\G"
     SLAVE_STATUS="${res}"
-    read SLAVE_IO_RUNNING SLAVE_SQL_RUNNING SECONDS_BEHIND_MASTER <<<$(echo "${SLAVE_STATUS}" | grep -v WARNING | egrep "Slave_IO_Running:|Slave_SQL_Running:|Seconds_Behind_Master:" | awk '{print $2}' 2>&1)
+    read -d '' SLAVE_IO_RUNNING SLAVE_SQL_RUNNING SECONDS_BEHIND_MASTER <<<$(echo "${SLAVE_STATUS}" | grep -v WARNING | egrep "Slave_IO_Running:|Slave_SQL_Running:|Seconds_Behind_Master:" | awk '{print $2}' 2>&1)
     
     if [ "${SLAVE_SQL_RUNNING}" != "Yes" ]
     then


### PR DESCRIPTION
#### Description of your patch
Fix /engineyard/bin/check_mysql.sh used by collectd.

#### Recommended Release Notes
Update script used by collectd for mysql replication checks.

#### Estimated risk
Low

#### Components involved
Collectd

#### Description of testing done
See QA instructions

#### QA Instructions
1. Boot a mysql environment with a db replica.
2. Check that mysql replication check does not fail.