### PR TITLE
[FB1220] Remove rrd dirs of non-existent private hostnames

### DIFF
--- a/cookbooks/collectd/recipes/default.rb
+++ b/cookbooks/collectd/recipes/default.rb
@@ -162,3 +162,14 @@ execute "cleanup_original_collectd_conf" do
   }
   only_if { File.exist?('/etc/collectd/collectd.conf') }
 end
+
+#FB1220 - RRD data is inherited from AMI. This will remove folders other than the one with private hostname as name
+instance = node.dna.engineyard.environment.instances.detect { |i| i['id'] == node.dna.engineyard['this'] }
+private_hostname=instance["private_hostname"]
+
+Dir['/var/lib/collectd/rrd/*'].reject{ |f| f["#{private_hostname}"] }.each do |path|
+  directory path do
+    recursive true
+    action :delete
+  end
+end


### PR DESCRIPTION
#### Description of your patch
Removes RRD data inherited by AMI

#### Recommended Release Notes
Fixes performance graphs on newly booted stack V6 recipes 

#### Estimated risk
Low

#### Components involved
Collectd recipe

#### Description of testing done
See QA instructions

#### QA Instructions
Boot QA stack
Verify that performance graphs work
Verify that there is only one directory under /var/lib/collectd/rrd and it's named after the current private hostname of the instance 