### PR TITLE
[FB-582] Run e2fsck before mounting /data

### DIFF
--- a/cookbooks/ec2/recipes/default.rb
+++ b/cookbooks/ec2/recipes/default.rb
@@ -32,6 +32,10 @@ if data_mounted.stdout == ""
         not_if "e2label #{node['data_volume'].device}"
       end
 
+      execute "e2fsck -f -y #{node['data_volume'].device}" do
+        ignore_failure true
+      end
+
       mount "/data" do
         fstype node['data_filesystem']
         device node['data_volume'].device


### PR DESCRIPTION
#### Description of your patch
Run e2fsck to fix issues when using snapshots to boot instances.

#### Recommended Release Notes
Run filesystem check to fix issues when using snapshots to boot instances.

#### Estimated risk
Low

#### Components involved
Volume setup

#### Description of testing done
See QA instructions

#### QA Instructions
1. Boot an environment with an application master.
2. Boot an app instance using a snapshot.
3. The instance should be green.