### PR TITLE
Yarn

### DIFF
--- a/cookbooks/app/recipes/create.rb
+++ b/cookbooks/app/recipes/create.rb
@@ -65,6 +65,8 @@ end
   # the recipes are monit, nginx, and depending on the stack passenger5, puma, or unicorn
   app.recipes.each do |recipe|
     next if recipe == "memcached"
+    #skipping node::tcp recipe run. This acts as a workaround for nodejs apps till EYPP-11098 is fixed
+    next if recipe == "node::tcp"
     include_recipe recipe
   end
 

--- a/cookbooks/ey-base/recipes/post_bootstrap.rb
+++ b/cookbooks/ey-base/recipes/post_bootstrap.rb
@@ -1,6 +1,7 @@
 include_recipe "monit"
 include_recipe "collectd"
 include_recipe "nodejs::common"
+include_recipe "nodejs::yarn"
 include_recipe "reboot"
 
 file "/etc/engineyard/recipe-revision.txt" do

--- a/cookbooks/nodejs/recipes/yarn.rb
+++ b/cookbooks/nodejs/recipes/yarn.rb
@@ -1,14 +1,9 @@
-execute "add key from yarn repository" do
-  command "curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -"
-  not_if 'apt-key adv --list-public-key --with-fingerprint --with-colons | grep Yarn -q'
+apt_repository 'yarn' do
+  uri 'https://dl.yarnpkg.com/debian/'
+  components ['main', 'stable']
+  key 'https://dl.yarnpkg.com/debian/pubkey.gpg'
+  action :add
 end
-
-file "apt source yarn" do
-  path "/etc/apt/sources.list.d/yarn.list"
-  content "deb https://dl.yarnpkg.com/debian/ stable main"
-  notifies :run, "execute[update-apt]", :immediately
-end
-
 
 package "yarn" do
   action :install

--- a/cookbooks/nodejs/recipes/yarn.rb
+++ b/cookbooks/nodejs/recipes/yarn.rb
@@ -1,0 +1,15 @@
+execute "add key from yarn repository" do
+  command "curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -"
+  not_if 'apt-key adv --list-public-key --with-fingerprint --with-colons | grep Yarn -q'
+end
+
+file "apt source yarn" do
+  path "/etc/apt/sources.list.d/yarn.list"
+  content "deb https://dl.yarnpkg.com/debian/ stable main"
+  notifies :run, "execute[update-apt]", :immediately
+end
+
+package "yarn" do
+  action :install
+  options '--no-install-recommends'
+end

--- a/cookbooks/nodejs/recipes/yarn.rb
+++ b/cookbooks/nodejs/recipes/yarn.rb
@@ -9,6 +9,7 @@ file "apt source yarn" do
   notifies :run, "execute[update-apt]", :immediately
 end
 
+
 package "yarn" do
   action :install
   options '--no-install-recommends --allow-downgrades'

--- a/cookbooks/nodejs/recipes/yarn.rb
+++ b/cookbooks/nodejs/recipes/yarn.rb
@@ -11,5 +11,5 @@ end
 
 package "yarn" do
   action :install
-  options '--no-install-recommends'
+  options '--no-install-recommends --allow-downgrades'
 end


### PR DESCRIPTION
#### Description of your patch
Installs yarn. It is installed on all instances and the latest version available on repo "https://dl.yarnpkg.com/debian/" is being used. One can install any other version by utilizing the [custom-packages](https://github.com/engineyard/ey-cookbooks-stable-v6/tree/next-release/custom-cookbooks/packages) recipe, by adding:

```
{'name' => "yarn", 'version' => "1.0.1-1",'allow_downgrades' => true}
```

#### Recommended Release Notes
Yarn is now available an all instances

#### Estimated risk
Low

#### Components involved
Nodejs recipe

#### Description of testing done
See QA instructions

#### QA Instructions
Boot QA stack
Use ruby
Verify that yarn is installed: `yarn --version`
Install a different version using custom-packages recipe
Verify that version is changed
Verify that no deploy/chef errors are seen