### PR TITLE
[FB-1257] Start and enable collectd httpd

### DIFF
--- a/cookbooks/collectd/recipes/httpd.rb
+++ b/cookbooks/collectd/recipes/httpd.rb
@@ -48,25 +48,18 @@ cookbook_file "/etc/systemd/system/fcgiwrap.service.d/override.conf" do
   notifies :restart, "service[fcgiwrap]", :delayed
 end
 
-service "collectd-httpd" do
-  provider Chef::Provider::Service::Systemd
-  action :nothing
-end
-
 cookbook_file "/etc/systemd/system/collectd-httpd.service" do
   source 'collectd-httpd.service'
   owner 'root'
   group 'root'
   mode 0644
   notifies :run, "execute[reload-systemd]", :immediately
-  notifies :enable, "service[collectd-httpd]", :immediately
-  notifies :start, "service[collectd-httpd]", :immediately
+  notifies :restart, "service[collectd-httpd]", :immediately
 end
 
-service "start collectd-httpd" do
-  service_name "collectd-httpd"
+service "collectd-httpd" do
   provider Chef::Provider::Service::Systemd
-  action :start
+  action [:start, :enable]
 end
 
 package "apache2-utils"

--- a/cookbooks/collectd/recipes/httpd.rb
+++ b/cookbooks/collectd/recipes/httpd.rb
@@ -63,6 +63,12 @@ cookbook_file "/etc/systemd/system/collectd-httpd.service" do
   notifies :start, "service[collectd-httpd]", :immediately
 end
 
+service "start collectd-httpd" do
+  service_name "collectd-httpd"
+  provider Chef::Provider::Service::Systemd
+  action :start
+end
+
 package "apache2-utils"
 
 # Setup HTTP auth so AWSM can get at the graphs

--- a/cookbooks/collectd/recipes/httpd.rb
+++ b/cookbooks/collectd/recipes/httpd.rb
@@ -57,6 +57,11 @@ cookbook_file "/etc/systemd/system/collectd-httpd.service" do
   notifies :restart, "service[collectd-httpd]", :immediately
 end
 
+service 'fcgiwrap.socket' do
+  provider Chef::Provider::Service::Systemd
+  action :enable
+end
+
 service "collectd-httpd" do
   provider Chef::Provider::Service::Systemd
   action [:start, :enable]


### PR DESCRIPTION
#### Description of your patch
Start and enable collectd httpd

#### Recommended Release Notes
Start collectd httpd after a reboot

#### Estimated risk
Low

#### Components involved
Collectd

#### Description of testing done
See QA instructions

#### QA Instructions
1. Boot an environment.
2. Reboot the solo or app master.
3. Check that collectd-httpd is running `systemctl status collectd-httpd`