### PR TITLE
Fixing distribution name

### DIFF
--- a/cookbooks/nodejs/recipes/yarn.rb
+++ b/cookbooks/nodejs/recipes/yarn.rb
@@ -1,6 +1,7 @@
 apt_repository 'yarn' do
   uri 'https://dl.yarnpkg.com/debian/'
-  components ['main', 'stable']
+  distribution 'stable'
+  components ['main']
   key 'https://dl.yarnpkg.com/debian/pubkey.gpg'
   action :add
 end


### PR DESCRIPTION
PR to fix issues found while QAing https://github.com/engineyard/ey-cookbooks-stable-v6/pull/132

File _/etc/apt/sources.list.d/yarn.list_ was populated as such:

```
deb      https://dl.yarnpkg.com/debian/ bionic stable main
```

while the following was expected:

```
deb      https://dl.yarnpkg.com/debian/ stable main
```

