### PR TITLE
[FB-652] Changing the Default Memory Limit to 250MB

### DIFF
--- a/cookbooks/passenger5/recipes/monitoring.rb
+++ b/cookbooks/passenger5/recipes/monitoring.rb
@@ -22,7 +22,7 @@ if ['app_master', 'app', 'solo'].include?(node['dna']['instance_role'])
     end
 
     # When a Rack process grows to a certain size, passenger_monitor will try to kill it:
-    max_megabytes = metadata_app_get_with_default(app_name, :worker_memory_size, 800)
+    max_megabytes = metadata_app_get_with_default(app_name, :worker_memory_size, 250)
 
     # We want to make sure there are at least this many Rack processes running on each app instance:
     min_rack_processes = (node[:dna][:environment][:framework_env] == 'production') ? 3 : 1


### PR DESCRIPTION
Description of your patch
-------------
Change the default passenger memory limit from `800MB` to `250MB`

Recommended Release Notes
-------------
Through this PR, the current default memory limit of `800MB` for `passenger-v5` would be reverted back to `250MB`

Estimated risk
-------------
Security Risk not applied. The number of possible worker limit would get increased for each instance

Components involved
-------------
`passenger-5` cookbook

Description of testing done
-------------
1. Boot a new instance under new stack version (In my case custom made one with the branch of applied changes to passenger-5)
2. Check the current memory limit by studying `crontab -e`, regarding the memory about defined as a parameter of `/engineyard/bin/passenger_monitor`

QA Instructions
-------------
1. Check with a solo environment
2. Check for environments with multiple instances