### PR TITLE
[FB-728] Lock db version file not written during the first cookbooks run with PG

### DIFF
--- a/cookbooks/postgresql/recipes/server_configure.rb
+++ b/cookbooks/postgresql/recipes/server_configure.rb
@@ -285,3 +285,15 @@ ruby_block 'process extensions.json' do
   end
   only_if { ::File.exist?(node[:pg_extensions_file]) }
 end
+
+ruby_block "writing initial lock version file" do
+  block do
+    while running_pg_version.empty?
+      sleep 1
+    end
+    File.open(node['lock_version_file'], "w") do |f|     
+      f.write(running_pg_version)   
+    end
+  end
+  only_if { lock_db_version and not File.exists?(node['lock_version_file']) and pg_running }
+end


### PR DESCRIPTION
Description of your patch
-------------
This PR adds a code block which writes the db lock file for PostgreSQL on the first cookbooks run. This is necessary to ensure that the lock file is present on any db snapshot which could subsequently be used to boot a db slave.

Recommended Release Notes
-------------
Enhances the PostgreSQL recipes to write the DB version lock file on the initial cookbooks run.

Estimated risk
-------------
Medium. Existing behaviour should not be adversely affected. Still it touches an important area.

Components involved
-------------
postgresql recipes

Dependencies
-------------
None

Description of testing done
-------------
Created a testing stack with the changes in this PR.
Booted an environment (PG 11, lock db version set, production configuration).
Checked if the environment booted correctly.
Checked if the db lock file was written during the initial cookbooks run on the db master.
Checked if the lock file was present on the snapshot for provisioning the slave instance.

QA Instructions
-------------
Test a PHP application.
Test different environment configurations.