### PR TITLE
Nginx syslog support

### DIFF
--- a/cookbooks/nginx/attributes/default.rb
+++ b/cookbooks/nginx/attributes/default.rb
@@ -8,3 +8,4 @@ default['nginx']['systemd_mask'] = if %w(app_master app solo).include?(node['dna
                                      true
                                    end
 default['nginx']['syslog'] = false
+default['nginx']['syslog_path'] = 'syslog:server=unix:/var/log/nginx.sock'

--- a/cookbooks/nginx/attributes/default.rb
+++ b/cookbooks/nginx/attributes/default.rb
@@ -7,3 +7,4 @@ default['nginx']['systemd_mask'] = if %w(app_master app solo).include?(node['dna
                                      # Mask nginx on non-app instances
                                      true
                                    end
+default['nginx']['syslog'] = false

--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -137,7 +137,8 @@ node.engineyard.apps.each_with_index do |app, index|
         :xlb_nginx_port => nginx_xlb_http_port,
         :upstream_port => app_base_port,
         :http2 => false,
-        :syslog_enabled => node['nginx']['syslog']
+        :syslog_enabled => node['nginx']['syslog'],
+        :syslog_path => node['nginx']['syslog_path']
       })
       notifies :restart, resources(:service => "nginx"), :delayed
     end

--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -136,7 +136,8 @@ node.engineyard.apps.each_with_index do |app, index|
         :haproxy_nginx_port => nginx_haproxy_http_port,
         :xlb_nginx_port => nginx_xlb_http_port,
         :upstream_port => app_base_port,
-        :http2 => false
+        :http2 => false,
+        :syslog_enabled => node['nginx']['syslog']
       })
       notifies :restart, resources(:service => "nginx"), :delayed
     end

--- a/cookbooks/nginx/templates/default/nginx_app.conf.erb
+++ b/cookbooks/nginx/templates/default/nginx_app.conf.erb
@@ -82,12 +82,18 @@ server {
   #
   # Log files are stored within the /var/log/engineyard/nginx/ directory.
   #
+  <% log_prefix = if @syslog_enabled
+       'syslog:server=unix:'
+       else
+       ''
+       end
+  %>
   <% if @ssl %>
-  access_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.ssl.access.log main;
-  error_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.ssl.error.log notice;
+  access_log <%=log_prefix%>/var/log/engineyard/nginx/<%= @vhost.app.name %>.ssl.access.log main;
+  error_log <%=log_prefix%>/var/log/engineyard/nginx/<%= @vhost.app.name %>.ssl.error.log notice;
   <% else %>
-  access_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.access.log main;
-  error_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.error.log notice;
+  access_log <%=log_prefix%>/var/log/engineyard/nginx/<%= @vhost.app.name %>.access.log main;
+  error_log <%=log_prefix%>/var/log/engineyard/nginx/<%= @vhost.app.name %>.error.log notice;
   <% end %>
 
   # Adding CORS Header to the font files.

--- a/cookbooks/nginx/templates/default/nginx_app.conf.erb
+++ b/cookbooks/nginx/templates/default/nginx_app.conf.erb
@@ -82,18 +82,15 @@ server {
   #
   # Log files are stored within the /var/log/engineyard/nginx/ directory.
   #
-  <% log_prefix = if @syslog_enabled
-       'syslog:server=unix:'
-       else
-       ''
-       end
-  %>
-  <% if @ssl %>
-  access_log <%=log_prefix%>/var/log/engineyard/nginx/<%= @vhost.app.name %>.ssl.access.log main;
-  error_log <%=log_prefix%>/var/log/engineyard/nginx/<%= @vhost.app.name %>.ssl.error.log notice;
+  <% if @syslog_enabled %>
+  access_log <%= @syslog_path %>;
+  error_log <%= @syslog_path %>;
+  <% elsif @ssl %>
+  access_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.ssl.access.log main;
+  error_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.ssl.error.log notice;
   <% else %>
-  access_log <%=log_prefix%>/var/log/engineyard/nginx/<%= @vhost.app.name %>.access.log main;
-  error_log <%=log_prefix%>/var/log/engineyard/nginx/<%= @vhost.app.name %>.error.log notice;
+  access_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.access.log main;
+  error_log /var/log/engineyard/nginx/<%= @vhost.app.name %>.error.log notice;
   <% end %>
 
   # Adding CORS Header to the font files.


### PR DESCRIPTION
Sorry for the fist PR being pointless. 

Hi there, I hope this works, it looked to be oriented more for internal stakeholders. Essentially I wanted the ability to have my logs default to syslog formatted, so I could then configure syslog-ng to parse my logs and send them up to a centralized system.

Description of your patch
This is a small patch to enable the pretend log paths with syslog to ensure syslog syntax is used.

Recommended Release Notes
Added support for syslog formatted logs

Estimated risk
No risk, feature requires opting in by customer, so default behavior remains.

Components involved
nginx, syslog

Dependencies
nginx

Description of testing done
Ran the app erb file locally and it generated the expected syntax.

QA Instructions
Include the cookbook and set the attribute:
default['nginx']['syslog'] = true
which should then have nginx use syslog format.