### PR TITLE
[FB-1437] Adding custom recipe snaps-removal

### DIFF
--- a/custom-cookbooks/snaps-removal/README.md
+++ b/custom-cookbooks/snaps-removal/README.md
@@ -1,0 +1,5 @@
+# snaps-removal
+
+This recipe will permanently destroy and reset all state in `snapd`.
+
+See [cookbooks/custom-snaps-removal](cookbooks/custom-snaps-removal/README.md) for complete instructions.

--- a/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/README.md
+++ b/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/README.md
@@ -1,10 +1,6 @@
 # custom-snaps-removal
 
-The sidekiq Cookbook creates a sidekiq script that runs Sidekiq and a monit
-config file. Each application on the environment will get its own sidekiq
-workers.
-
-You need to add the sidekiq gem to your app.
+The Cookbook places and runs a bash script which will unmount and remove any snaps.
 
 ## Installation
 
@@ -12,49 +8,27 @@ For simplicity, we recommend that you create the `cookbooks/` directory at the
 root of your application. If you prefer to keep the infrastructure code separate
 from application code, you can create a new repository.
 
-Our main recipes have the `sidekiq` Cookbook but it is not included by default.
-To use the `sidekiq` cookbook, you should copy this cookbook
-`custom-sidekiq`. You should not copy the actual `sidekiq` recipe as
-this is managed by Engine Yard.
-
 1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
 
-    include_recipe 'custom-sidekiq'
+```
+include_recipe 'custom-snaps-removal'
+```
 
 2. Edit `cookbooks/ey-custom/metadata.rb` and add
 
-    depends 'custom-sidekiq'
-
-3. Copy `custom-cookbooks/sidekiq/cookbooks/custom-sidekiq` to `cookbooks/`
-
-    cd ~ # Change this to your preferred directory. Anywhere but inside the
-         # application
-
-    git clone https://github.com/engineyard/ey-cookbooks-stable-v6
-    cd ey-cookbooks-stable-v6
-    cp custom-cookbooks/sidekiq/cookbooks/custom-sidekiq /path/to/app/cookbooks/
-
-	If you do not have `cookbooks/ey-custom` on your app repository, you can copy
-`custom-cookbooks/sidekiq/cookbooks/ey-custom` to `/path/to/app/cookbooks` as well.
-
-4. Create or modify `config/initializers/sidekiq.rb`:
-
 ```
-redis_config = YAML.load_file(Rails.root + 'config/redis.yml')[Rails.env]
-
-Sidekiq.configure_server do |config|
-  config.redis = {
-    url: "redis://#{redis_config['host']}:#{redis_config['port']}"
-  }
-end
-
-Sidekiq.configure_client do |config|
-  config.redis = {
-    url: "redis://#{redis_config['host']}:#{redis_config['port']}"
-  }
-end
+depends 'custom-snaps-removal'
 ```
 
-The above code parses `config/redis.yml` to determine the Redis host. If you're using the [Redis recipe](https://github.com/engineyard/ey-cookbooks-stable-v6/tree/next-release/custom-cookbooks/redis), it creates a `/data/<app_name>/shared/config/redis.yml` for you.
+3. Copy `custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal` to `cookbooks/`
 
-During deployment, the file `/data/<app_name>/current/config/redis.yml` is automatically symlinked to `/data/<app_name>/shared/config/redis.yml`.
+```
+cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+git clone https://github.com/engineyard/ey-cookbooks-stable-v6
+cd ey-cookbooks-stable-v6
+cp custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal /path/to/app/cookbooks/
+```
+
+If you do not have `cookbooks/ey-custom` on your app repository, you can copy
+`custom-cookbooks/snaps-removal/cookbooks/ey-custom` to `/path/to/app/cookbooks` as well.

--- a/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/README.md
+++ b/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/README.md
@@ -1,0 +1,60 @@
+# custom-snaps-removal
+
+The sidekiq Cookbook creates a sidekiq script that runs Sidekiq and a monit
+config file. Each application on the environment will get its own sidekiq
+workers.
+
+You need to add the sidekiq gem to your app.
+
+## Installation
+
+For simplicity, we recommend that you create the `cookbooks/` directory at the
+root of your application. If you prefer to keep the infrastructure code separate
+from application code, you can create a new repository.
+
+Our main recipes have the `sidekiq` Cookbook but it is not included by default.
+To use the `sidekiq` cookbook, you should copy this cookbook
+`custom-sidekiq`. You should not copy the actual `sidekiq` recipe as
+this is managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+    include_recipe 'custom-sidekiq'
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+    depends 'custom-sidekiq'
+
+3. Copy `custom-cookbooks/sidekiq/cookbooks/custom-sidekiq` to `cookbooks/`
+
+    cd ~ # Change this to your preferred directory. Anywhere but inside the
+         # application
+
+    git clone https://github.com/engineyard/ey-cookbooks-stable-v6
+    cd ey-cookbooks-stable-v6
+    cp custom-cookbooks/sidekiq/cookbooks/custom-sidekiq /path/to/app/cookbooks/
+
+	If you do not have `cookbooks/ey-custom` on your app repository, you can copy
+`custom-cookbooks/sidekiq/cookbooks/ey-custom` to `/path/to/app/cookbooks` as well.
+
+4. Create or modify `config/initializers/sidekiq.rb`:
+
+```
+redis_config = YAML.load_file(Rails.root + 'config/redis.yml')[Rails.env]
+
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: "redis://#{redis_config['host']}:#{redis_config['port']}"
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: "redis://#{redis_config['host']}:#{redis_config['port']}"
+  }
+end
+```
+
+The above code parses `config/redis.yml` to determine the Redis host. If you're using the [Redis recipe](https://github.com/engineyard/ey-cookbooks-stable-v6/tree/next-release/custom-cookbooks/redis), it creates a `/data/<app_name>/shared/config/redis.yml` for you.
+
+During deployment, the file `/data/<app_name>/current/config/redis.yml` is automatically symlinked to `/data/<app_name>/shared/config/redis.yml`.

--- a/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/attributes/default.rb
+++ b/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/attributes/default.rb
@@ -1,0 +1,1 @@
+#no parameters are used at this point

--- a/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/files/default/snaps_remove.sh
+++ b/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/files/default/snaps_remove.sh
@@ -1,0 +1,50 @@
+if systemctl is-active --quiet snapd.service snapd.socket; then
+    snapd_was_active=yes
+    echo
+    echo "Stoping snapd..."
+    echo
+    (
+        set -x
+        systemctl stop snapd.socket snapd.service
+    )
+else
+    echo "Skipping stopping snapd as systemctl reports it's inactive."
+fi
+echo
+echo "Unmounting all snaps..."
+echo
+(
+    set -x
+    umount -l /var/lib/snapd/snaps/*.snap
+)
+echo
+echo "Removing all support files and state..."
+echo
+(
+    set -x
+    rm -rvf /var/lib/snapd/*
+)
+echo
+echo "Removing generated systemd units..."
+echo
+(
+    set -x
+    rm -vf /etc/systemd/system/snap-*.mount
+    rm -vf /etc/systemd/system/snap-*.service
+    rm -vf /etc/systemd/system/multi-user.target.wants/snap-*.mount
+)
+echo
+echo "Removing generated executable wrappers..."
+echo
+(
+    set -x
+    rm -vrf /snap/*
+)
+if [ "$snapd_was_active" = "yes" ]; then
+    echo
+    echo "Starting snapd"
+    (
+        set -x
+        systemctl start snapd.socket
+    )
+fi

--- a/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/metadata.rb
+++ b/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/metadata.rb
@@ -1,0 +1,1 @@
+name 'custom-snaps-removal'

--- a/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/recipes/default.rb
+++ b/custom-cookbooks/snaps-removal/cookbooks/custom-snaps-removal/recipes/default.rb
@@ -1,0 +1,10 @@
+cookbook_file "/root/snaps_remove.sh" do
+  source "snaps_remove.sh"
+  mode "744"
+end
+
+
+execute "Remove snaps from all instances" do
+  command "/root/snaps_remove.sh"
+  only_if { File.exists?("/root/snaps_remove.sh") }
+end

--- a/custom-cookbooks/snaps-removal/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/snaps-removal/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom-snaps-removal'

--- a/custom-cookbooks/snaps-removal/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/snaps-removal/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe 'custom-snaps-removal'


### PR DESCRIPTION
#### Description of your patch
This custom recipe can be used to unmount and remove any mounted snaps posing security risks.

#### Recommended Release Notes
Adds a new custom recipe to unmount and remove snaps.

#### Estimated risk
Low

#### Components involved
This is a new recipe

#### Dependencies
none

#### Description of testing done
See QA instructions

#### QA Instructions
Boot solo and multiple app env
Ensure chef is ran successfully
Verify that there are no snaps mount use `df -h` to verify
Leave the environment running for a few days
Verify that chef runs successfully
Reboot instances, verify that chef runs successfully
Stop/start instances, verify that chef runs successfully

