### PR TITLE
[FB-1933] Starting NTP service on chef run

### DIFF
--- a/cookbooks/ntp/recipes/default.rb
+++ b/cookbooks/ntp/recipes/default.rb
@@ -27,7 +27,7 @@ template "/etc/ntp.conf" do
   group 'root'
   mode 0644
   source "ntp.conf.erb"
-  variables({ 
+  variables({
     :servers => servers,
     :driftfile => "/var/lib/ntp/ntp.drift",
   })
@@ -50,6 +50,10 @@ service "ntp" do
   supports :status => true, :restart => true, :start => true, :stop => true
   subscribes :restart, 'package[ntp]'
   subscribes :restart, 'template[/etc/ntp.conf]'
+end
+
+service "ntp" do
+    action :start
 end
 
 # Script to check stale ntp endpoints -- cron for this is in ntp::cronjobs,

--- a/cookbooks/ntp/recipes/default.rb
+++ b/cookbooks/ntp/recipes/default.rb
@@ -53,7 +53,8 @@ service "ntp" do
 end
 
 service "ntp" do
-    action :start
+    provider Chef::Provider::Service::Systemd
+    action [:start, :enable]
 end
 
 # Script to check stale ntp endpoints -- cron for this is in ntp::cronjobs,


### PR DESCRIPTION
#### Description of your patch
Instructing systemd to start `ntp` service on chef run

#### Recommended Release Notes
NTP service is now started after an instance reboot

#### Estimated risk
Low

#### Components involved
NTP recipe

#### Dependencies
none

#### Description of testing done
See QA instructions

#### QA Instructions
Boot QA stack
Verify that ntp service is running: `systemctl status ntp`
Reboot instance
Verify that ntp service is running: `systemctl status ntp`
