### PR TITLE
[FB2006] Logging the real IP on custom networks CIDR on NGINX

### DIFF
--- a/cookbooks/nginx/templates/default/nginx-plusplus.conf.erb
+++ b/cookbooks/nginx/templates/default/nginx-plusplus.conf.erb
@@ -37,7 +37,8 @@ http {
   <% if @behind_proxy %>
   # Fixes the IP for instances behind HAProxy
   set_real_ip_from 10.0.0.0/8;
-  set_real_ip_from 172.31.0.0/16;
+  set_real_ip_from 172.16.0.0/12;
+  set_real_ip_from 192.168.0.0/16;
   set_real_ip_from 127.0.0.1/32;
   real_ip_header proxy_protocol;
   <% end %>


### PR DESCRIPTION
#### Description of your patch
This patch adds all 3 private network ranges to the list of IPs that nginx's considers as trusted sources to extract the real IP of client from

#### Recommended Release Notes
Fixes logging of the real IP on custom networks (VPCs)

#### Estimated risk
Low

#### Components involved
nginx

#### Dependencies
none

#### Description of testing done
See QA instructions

#### QA Instructions
Boot QA stack
Verify that chef run / deployment finishes successfully
Verify that the real IP of the client is being logged
Use HTTP/HTTPs traffic to test
Verify on solo / multi instance envs
Use different VPCs (with different CIDRs) to verify