### PR TITLE
[FB-1999] Fix OpenSSL dependency for Ruby 2.3

### DIFF
--- a/cookbooks/ruby/recipes/default.rb
+++ b/cookbooks/ruby/recipes/default.rb
@@ -53,7 +53,8 @@ bash "install ruby" do
       echo "Installing Ruby #{ruby}"
       mkdir -p /opt/rubies
       chown -R #{node['owner_name']}:#{node['owner_name']} /opt/rubies
-      DEBIAN_FRONTEND=noninteractive sudo -Eu #{node['owner_name']} ruby-install -r /opt/rubies #{ruby_name} #{ruby_version}
+      DEBIAN_FRONTEND=noninteractive sudo -Eu #{node['owner_name']} \
+        ruby-install --no-install-deps -r /opt/rubies #{ruby_name} #{ruby_version}
     fi
   EOH
 end

--- a/cookbooks/ruby/recipes/dependencies.rb
+++ b/cookbooks/ruby/recipes/dependencies.rb
@@ -1,8 +1,8 @@
-if node[:ruby][:version] =~ /^2\.3/
+if node[:ruby][:version] =~ /^2\.3\./
   package "libssl1.0-dev" do
     action :install
   end
-else # ruby 2.4
+else # >=ruby 2.4
   package "libssl-dev" do
     action :install
   end


### PR DESCRIPTION
Description of your patch
-------------
This PR reverts using `ruby-install` to also install dependencies for Ruby. It incorrectly handles dependencies for Ruby 2.3 which requires an older version of OpenSSL.

Recommended Release Notes
-------------
Fixes Ruby 2.3 installation issues.

Estimated risk
-------------
Low. We revert back to how we handled Ruby dependencies previously.

Components involved
-------------
Ruby recipes

Dependencies
-------------
None

Description of testing done
-------------
TC 1
1. Created a testing stack with the changes in this PR.
2. Booted an environment with a Ruby app using Ruby 2.3.
3. Deployed the app and checked if it works.
4. Manually tested the openssl gem on the instance.

TC2
1. Created a testing stack with the changes in this PR.
2. Booted an environment with a Ruby app using Ruby 2.6 with jemalloc.
3. Deployed the app and checked if it works.

QA Instructions
-------------
Test a Ruby 2.6 app.
Test upgrading an existing Ruby 2.3 environment to this stack version.