### PR TITLE
[FB-2137] Add Support for Ruby 2.7

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -137,7 +137,8 @@ class Chef
           :ruby_230   => "2.3.8",
           :ruby_240   => "2.4.9",
           :ruby_250   => "2.5.7",
-          :ruby_260   => "2.6.5"
+          :ruby_260   => "2.6.5",
+          :ruby_270   => "2.7.0"
         }
         if versions.has_key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]


### PR DESCRIPTION
Description of your patch
-------------
This PR adds support for Ruby 2.7.

Recommended Release Notes
-------------
Adds support for Ruby 2.7.

Estimated risk
-------------
Low. Only new Ruby version added. Nothing existing was modified.

Components involved
-------------
ey-lib recipes. Specifically, the `default_ruby_version` function.

Dependencies
-------------
Needs to be released with AMIs: `ey-ubuntu-18.04.0.9` (https://github.com/engineyard/ey-stable-v6-infrastructure/releases/tag/ami-v0.9)

Needs to be released **after** the following has been released:
* https://jira.devfactory.com/browse/EYPP-12375
* https://jira.devfactory.com/browse/EYPP-12376

Description of testing done
-------------
On a staging cloud (buckman) with the backend changes deployed and the `ruby_270` feature flag turned on.
**TC 1**
1. Created a dev stack with the changes in this PR.
2. Created an environment for the engineyard/todo app (branch: ruby270)
    a. Selected "Ruby 2.7"
3. Booted the environment and checked if the app deploys successfully.
4. Checked if the app works.
5. Checked on the instance if the active Ruby version is 2.7.

**TC 2**: same as TC 1, but with `EY_RUBY_JEMALLOC` set to `true`. Checked if Ruby 2.7 with jemalloc was used.

QA Instructions
-------------
* Test Ruby 2.6 and 2.5 apps.
* Test a PHP app.
* Test with different app servers.
* Test with MySQL.