### PR TITLE
[FB-2181] Add extra sleep before mkswap

### DIFF
--- a/cookbooks/ey-core/recipes/swap.rb
+++ b/cookbooks/ey-core/recipes/swap.rb
@@ -10,6 +10,7 @@ bash "make-swap-xvdc" do
       echo "Waiting for 1 second"
       sleep 1
     done
+    sleep 1
     mkswap /dev/xvdc1
     echo "> $?"
     swapon /dev/xvdc1


### PR DESCRIPTION
Description of your patch
-------------
This PR adds an extra sleep before calling `mkswap` to prevent a potential race condition.

Recommended Release Notes
-------------
Fixes a potential swap creation issue.

Estimated risk
-------------
Low. Just added a sleep command.

Components involved
-------------
ey-core recipes, swap.rb

Dependencies
-------------
None

Description of testing done
-------------
1. Created a dev stack with the changes in this PR.
2. Created and booted an environment.
3. Checked if everything works.
4. Logged into the instance and checked if the swap partition was created (`free`).
5. Checked the swap creation trace log in `/var/log` and verified if it behaved as expected.

QA Instructions
-------------
* Test a PHP app.
* Test different environment configurations.