### PR TITLE
[FB-873] fixes php environmental variables [ZD-160560]

### DIFF
--- a/cookbooks/env_vars/templates/default/env.cloud.erb
+++ b/cookbooks/env_vars/templates/default/env.cloud.erb
@@ -1,3 +1,7 @@
 <% @environment_variables.reject{|varname| varname[:name] =~ /^EY_/}.each do |variable| %>
+<% if node['dna']['applications'].first[1]['type'] == "php" then %>
+env[<%= variable[:name] %>]="<%= escape_variable_value(variable[:value]) %>"
+<% else %>
 export <%= variable[:name] %>="<%= escape_variable_value(variable[:value]) %>"
+<% end %>
 <% end %>


### PR DESCRIPTION
Description of your patch
-------------
Fixes the env_var cookbook which generates the variables for the environment from the EngineYard UI


Recommended Release Notes
-------------
Fixed PHP environmental variables

Estimated risk
-------------
High. Its a main cookbook and its run on ever instance however currently PHP is unable to start if environment variables are set 

Description of testing done
-------------
Booted multiple environments one PHP and one Ruby
Set custom variables on both instances
Pressed Apply
Checked that the correct variable was created

QA Instructions
-------------
Boot up an environment of your choice. Ruby, PHP, or NodeJS
Set `Environment Variables` via the EngineYard UI
Press apply
Make sure the application server process is able to start and there are no errors, along with the correct variables in place.