### PR TITLE
[ZD-160605] Fixes PHP set up on V6 

### DIFF
--- a/cookbooks/ey-base/recipes/post_bootstrap.rb
+++ b/cookbooks/ey-base/recipes/post_bootstrap.rb
@@ -1,6 +1,6 @@
 include_recipe "monit"
 include_recipe "collectd"
-include_recipe "php"
+include_recipe "php" if node['dna']['applications'].first[1]['type'] == 'php'
 include_recipe "nodejs::common"
 include_recipe "nodejs::yarn"
 include_recipe "reboot"

--- a/cookbooks/ey-base/recipes/post_bootstrap.rb
+++ b/cookbooks/ey-base/recipes/post_bootstrap.rb
@@ -1,5 +1,6 @@
 include_recipe "monit"
 include_recipe "collectd"
+include_recipe "php"
 include_recipe "nodejs::common"
 include_recipe "nodejs::yarn"
 include_recipe "reboot"

--- a/cookbooks/php/recipes/default.rb
+++ b/cookbooks/php/recipes/default.rb
@@ -1,6 +1,6 @@
 include_recipe "php::install"
 include_recipe "php::configure"
 include_recipe "php::composer"
-if ['app_master', 'app', 'solo'].include? node['dna']['instance_role'] && node['dna']['applications'].first[1]['type'] == 'php'
+if ['app_master', 'app', 'solo'].include? node['dna']['instance_role']
   include_recipe "php::fpm"
 end

--- a/cookbooks/php/recipes/default.rb
+++ b/cookbooks/php/recipes/default.rb
@@ -1,6 +1,6 @@
 include_recipe "php::install"
 include_recipe "php::configure"
 include_recipe "php::composer"
-if ['app_master', 'app', 'solo'].include? node['dna']['instance_role']
+if ['app_master', 'app', 'solo'].include? node['dna']['instance_role'] && node['dna']['applications'].first[1]['type'] == 'php'
   include_recipe "php::fpm"
 end


### PR DESCRIPTION
**Description of your patch**

-------


Fixes how we configure and set up v6 on the EngineYard stack. Previously composer wasn't installed on other instances which was on issue for utility instances along with installing FPM only on application instances (master, solo, slaves)


--------


**Estimated risk**

--------

_High_. Its a main cookbook and its run on every instances if its PHP or not similar to how it acted on v5 stack. 



**Description of testing done**

------

* Booted multiple environments one PHP and one Ruby (Different configurations multiple times)
* Ensures composer was installed on all instances
* Ensures PHP was installed
* Made sure FPM wasn't installed or attempting to be set up on Ruby
* Made sure FPM was running on PHP and the application was working


--------


**QA Instructions**

----

* Boot up multiple environments PHP and either nodeJS or Ruby
* Make sure PHP modules and composer is installed on the instances similar to node and yarn
* Make sure FPM is running on the PHP application instances
* Make sure PHP FPM doesn't attempt to start or install on the other environment
