### PR TITLE
[FB-2510] Ensures DJ spawns as deploy

### DIFF
--- a/cookbooks/delayed_job4/templates/default/dj.erb
+++ b/cookbooks/delayed_job4/templates/default/dj.erb
@@ -158,7 +158,7 @@ if [ -d $RAILS_ROOT ]; then
 
       if [ $RESULT -eq 0 ]; then
         logger -t "monit-dj:$WORKER[$$]" "issuing command $COMMAND in $PWD for $USER"
-        start-stop-daemon --start -b -m -u $USER -d $RAILS_ROOT -p $PID_FILE --exec /bin/bash -- -c "$COMMAND"
+        start-stop-daemon --start -b -m -c $USER -d $RAILS_ROOT -p $PID_FILE --exec /bin/bash -- -c "$COMMAND"
         RESULT=$?
         logger -t "monit-dj:$WORKER[$$]" "$WORKER started as  `cat $PID_FILE` : $RESULT"
       fi


### PR DESCRIPTION
Description of your patch
-------------
This patch updates the `start-stop-daemon` argument to be Ubuntu compatible for setting the user as which the DJ process is spawned.

Recommended Release Notes
-------------
Ensures the Delayed Job processes are run as the application owner user rather than the root user.

Estimated risk
-------------
Low - a single argument change.

Components involved
-------------
Main delayed_job_4 recipe.

Description of testing done
-------------
Changed the argument from `-u` to `-c` directly in the `/engineyard/custom/dj` on an existing v6 instance and restarted DJ via Monit.

QA Instructions
-------------
Boot a v6 instance or cluster and enable the custom-delayed_job4 recipe so that DJ is set to run on an instance. Ensure the `ruby /data/_app_name_/current/bin/rails runner -e _rails_env_ require 'delayed/command';Delayed::Worker.before_fork;Delayed::Command.new` process is running as the `deploy` user and not the `root` user.