### PR TITLE
[TEY-147] Redirect assets to ssl app stream when ssl is enabled

### DIFF
--- a/cookbooks/nginx/templates/default/nginx_app.conf.erb
+++ b/cookbooks/nginx/templates/default/nginx_app.conf.erb
@@ -100,7 +100,11 @@ server {
   #
   # set Expire header on assets: see http://developer.yahoo.com/performance/rules.html#expires
   location ~ ^/(images|assets|javascripts|stylesheets)/ {
+  <% if @ssl %>
+  try_files  $uri $uri/index.html /last_assets/$uri /last_assets/$uri.html @app_<%=@vhost.app.name%>ssl;
+  <% else %>
   try_files  $uri $uri/index.html /last_assets/$uri /last_assets/$uri.html @app_<%=@vhost.app.name%>;
+  <% end %>
   expires 10y;
   }
 


### PR DESCRIPTION
Description of your patch
-------------
This PR changes the nginx config to redirect assets to the ssl app stream when ssl is enabled.

Recommended Release Notes
-------------
Redirects assets to ssl app stream when ssl is enabled

Estimated risk
-------------
Low. Just a minor change in the nginx config.

Components involved
-------------
nginx recipes

Dependencies
-------------
None

Description of testing done
-------------
1. Booted a Ruby staging environment (Unicorn) with the changes in this PR.
2. Configured SSL for the environment.
3. Checked if it applies correctly, deploy succeeds, and app works.
4. Checked if the nginx ssl config file redirects to the ssl app stream in both try_files directives.

QA Instructions
-------------
Test different app servers (passenger).
Test a PHP app.