### PR TITLE
[TEY-151] Explicitly set umask in collect check scripts

### DIFF
--- a/cookbooks/collectd/files/default/check_health_for
+++ b/cookbooks/collectd/files/default/check_health_for
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+umask 022
+
 ACTION=$1
 WARN=$2
 CRIT=$3

--- a/cookbooks/collectd/files/default/check_readonly.sh
+++ b/cookbooks/collectd/files/default/check_readonly.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+umask 022
+
 # make tmp dir
 status_dir="/tmp/check_readonly_status"
 mkdir -p "${status_dir}"

--- a/cookbooks/postgresql/templates/default/check_postgres_wrapper.sh.erb
+++ b/cookbooks/postgresql/templates/default/check_postgres_wrapper.sh.erb
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+umask 022
+
 ACTION=$1
 shift
 OTHER_OPTS="${*}"


### PR DESCRIPTION
Description of your patch
-------------
This PR sets an appropriate umask in the collectd check scripts. This avoids wrong permissions on check directories in /tmp.

Recommended Release Notes
-------------
Fixes incorrect permissions of directories created by collectd check scripts

Estimated risk
-------------
Low. Just umask statements added to check scripts.

Components involved
-------------
collectd recipes, postgresql recipes

Dependencies
-------------
None

Description of testing done
-------------
Booted multiple environments and checked if the check directories were created with correct permissions.

QA Instructions
-------------
Test different environment configurations.
Test with a MySQL database.
Test a PHP app.