### PR TITLE
[TEY-157] Restores loading of custom ssl ciphers

### DIFF
--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -321,7 +321,7 @@ node.engineyard.apps.each_with_index do |app, index|
     end
 
     # Add Cipher chain
-    template "/data/nginx/ssl/#{app.name}/default.ssl_cipher" do
+    template "/data/nginx/servers/#{app.name}/default.ssl_cipher" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644
@@ -337,7 +337,7 @@ node.engineyard.apps.each_with_index do |app, index|
     # Chain files are create if missing and do not reload Nginx
 
     # Add Cipher chain
-    template "/data/nginx/ssl/#{app.name}/customer.ssl_cipher" do
+    template "/data/nginx/servers/#{app.name}/customer.ssl_cipher" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644
@@ -349,7 +349,7 @@ node.engineyard.apps.each_with_index do |app, index|
     end
 
     # Add Cipher chain
-    template "/data/nginx/ssl/#{app.name}/ssl_cipher" do
+    template "/data/nginx/servers/#{app.name}/ssl_cipher" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644

--- a/cookbooks/nginx/templates/default/customer_ssl_cipher.erb
+++ b/cookbooks/nginx/templates/default/customer_ssl_cipher.erb
@@ -15,7 +15,7 @@ include /etc/nginx/servers/<%= @app_name %>/default.ssl_cipher;
 #  ssl_prefer_server_ciphers on;
 
   <% if @dhparam_available %>
-#  ssl_dhparam /etc/nginx/ssl/dhparam.<%= @app_name %>.pem;
+#  ssl_dhparam /etc/nginx/ssl/<%= @app_name %>/dhparam.<%= @app_name %>.pem;
   <% end %>
 
 # Please remember to periodically check /etc/nginx/servers/<%= @app_name %>/default.ssl_cipher for changes

--- a/cookbooks/nginx/templates/default/default_ssl_cipher.erb
+++ b/cookbooks/nginx/templates/default/default_ssl_cipher.erb
@@ -10,5 +10,5 @@
   ssl_prefer_server_ciphers on;
 
   <% if @dhparam_available %>
-  ssl_dhparam /etc/nginx/ssl/dhparam.<%= @app_name %>.pem;
+  ssl_dhparam /etc/nginx/ssl/<%= @app_name %>/dhparam.<%= @app_name %>.pem;
   <% end %>

--- a/cookbooks/nginx/templates/default/nginx_app.conf.erb
+++ b/cookbooks/nginx/templates/default/nginx_app.conf.erb
@@ -49,6 +49,7 @@ server {
   server_name _;
 <% end %>
 
+  <% if @ssl %>
   #
   # SSL certificates
   #
@@ -58,10 +59,10 @@ server {
   # start up the Nginx server the password will need to be typed in every time.
   # This precludes automatic/automated web server restarts on boot or otherwise.
   #
-  <% if @ssl %>
   ssl on;
   ssl_certificate /etc/nginx/ssl/<%= @vhost.app.name %>/<%= @vhost.app.name %>.crt;
   ssl_certificate_key /etc/nginx/ssl/<%= @vhost.app.name %>/<%= @vhost.app.name %>.key;
+  include /etc/nginx/servers/<%= @vhost.app.name %>/ssl_cipher;
   <% end %>
 
   #


### PR DESCRIPTION
Description of your patch
-------------
Restores loading of dedicated ssl_cipher files in app level nginx config, lost in v5 migration, allowing for customisation of SSL protocols and ciphers by customers.

Recommended Release Notes
-------------
Adds support for custom SSL protocols and ciphers for Nginx.

Estimated risk
-------------
Medium - small changes (taken from v5 recipes) to key cookbook impacting all environments regardless of application server stack.

The change in directory for storing ssl_cipher files will leave orphaned files in `/etc/nginx/ssl` It should not impact any customers' custom ssl_ciphers as although the files will be recreated as new under `/etc/nginx/servers` that file will not being called by nginx and so unused.

Components involved
-------------
Nginx recipe and templates.

Description of testing done
-------------
Booted v6 solo Unicorn environment and applied updated recipe and template files via overlays. Ran multiple apply runs and manual Nginx restarts.

QA Instructions
-------------
Boot multi-instance environments with app server stack passenger, unicorn and puma.
Boot multi-instance environment with PHP app.