### PR TITLE
[TEY-181] Install the system Ruby for PHP applications

### DIFF
--- a/cookbooks/php/recipes/default.rb
+++ b/cookbooks/php/recipes/default.rb
@@ -1,3 +1,4 @@
+include_recipe "php::system_ruby"
 include_recipe "php::install"
 include_recipe "php::configure"
 include_recipe "php::composer"

--- a/cookbooks/php/recipes/system_ruby.rb
+++ b/cookbooks/php/recipes/system_ruby.rb
@@ -1,0 +1,4 @@
+## Install the ruby package. Newer versions of serverside need a Ruby available.
+package "ruby" do
+  action :install
+end


### PR DESCRIPTION
Description of your patch
-------------
This PR installs the OS default Ruby package for a PHP application. This is needed for newer versions of serverside (>= 2.8.0) to work properly.

Recommended Release Notes
-------------
Ensures that Ruby is installed even on non-Ruby applications.

Estimated risk
-------------
Low. Just installs the `ruby` OS package.

Components involved
-------------
php recipes

Dependencies
-------------
None

Description of testing done
-------------
1. Tested upgrading an existing PHP environment and verified that the deploy issue with serverside 2.8.0 is fixed.
2. Tested booting a new PHP environment and verified that the Chef run completes successfully and the app deploys successfully with serverside 2.8.0.

QA Instructions
-------------
Test a Ruby application.
Test different environment configurations.