### PR TITLE
[TEY-197] Disable binary logging on solo environments

### DIFF
--- a/cookbooks/mysql/recipes/default.rb
+++ b/cookbooks/mysql/recipes/default.rb
@@ -78,6 +78,7 @@ managed_template "/etc/mysql/percona-server.cnf" do
       :innodb_buff => innodb_buff,
       :replication_master => node['dna']['instance_role'] == 'db_master',
       :replication_slave  => node['dna']['instance_role'] == 'db_slave',
+      :solo_environment  => node['dna']['instance_role'] == 'solo',
       :server_id    => server_id,
     }
   })

--- a/cookbooks/mysql/templates/default/my.conf.erb
+++ b/cookbooks/mysql/templates/default/my.conf.erb
@@ -79,6 +79,9 @@ log-slave-updates = 1
 binlog-format  = MIXED
 <% end %>
 sync_binlog = 0
+<% if @solo_environment %>
+skip-log-bin
+<% end %>
 
 # END master/slave configuration
 


### PR DESCRIPTION
Description of your patch
-------------
This PR disables binary logging on solo environments where binary logging is unnecessary. In earlier MySQL versions, binary logging was disabled by default and was enabled if we specified the --log-bin option. From MySQL 8.0, binary logging is enabled by default, whether or not we specify the --log-bin option. 
 
Recommended Release Notes
-------------
Disables MySQL binary logging for solo environments.

Estimated risk
-------------
Low. Adds `skip-log-bin` parameter to the MySQL configuration file.

Components involved
-------------
MySQL 8.0

Dependencies
-------------
None

Description of testing done
-------------
MySQL 5.6 on a solo environment.
MySQL 5.7 on a solo environment.
MySQL 8.0 on a solo environment.
MySQL 8.0 on a clustered environment (binary logging should stay enabled on a clustered environment).

 
QA Instructions
-------------
To check if binary logging is enabled run `mysql -e "select @@log_bin"` .
1 means enabled, 0 means disabled.