### PR TITLE
[TEY-207] moves db-ssl recipe call outside of postgres if statement

### DIFF
--- a/cookbooks/ey-init/recipes/integrate.rb
+++ b/cookbooks/ey-init/recipes/integrate.rb
@@ -13,8 +13,8 @@ when 'util'
 when /^db/
   if node.engineyard.environment['db_stack_name'][/^postgres/]
     include_recipe 'ey-backup::postgres'
-    is_db_master = ['db_master'].include?(node.dna['instance_role'])
-    include_recipe "db-ssl::setup" if is_db_master
   end
+  is_db_master = ['db_master'].include?(node.dna['instance_role'])
+  include_recipe "db-ssl::setup" if is_db_master
 end
 include_recipe "ssh_keys" # CC-691 - update ssh whitelist after takeovers


### PR DESCRIPTION
Description of your patch
-------------
Ensures that db-ssl certificates are copied out to new instances from the DB master instance on the post-integration quick run. These were previously failing for MySQL environments.

Recommended Release Notes
-------------
Fixes an issue where DB SSL certificates were not put in place on new instances in MySQL environments.

Estimated risk
-------------
Low - is a simple change to make applicable block in recipe identical to functioning v5 recipe.

Components involved
-------------
Main chef, `ey-init` (quick chef run) recipe.

Dependencies
-------------
None.

Description of testing done
-------------
Without the fix:
* Added a utility instance
* Confirmed that integration completed and quick chef ran on the DB master
* Checked that `/home/deploy/.mysql` did not exist on the new utility instance
* Checked that there was no mention of db-ssl in the DB master quick run Chef log

With the fix:
* Added a utility instance
* Confirmed that integration completed and quick chef ran on the DB master
* Checked that `/home/deploy/.mysql` did exist on the new utility instance
* Checked that there was mention of db-ssl in the DB master quick run Chef log

QA Instructions
-------------
Should be tested on an app instance in a Passenger environment to ensure that when integration succeeds the db certs are copied to the new app instance.
We know for sure that integration will fail on Unicorn environments, so quick chef will not get run (a full Apply has to be run to put certs in place), so maybe trigger just the ey-init recipe on the DB master of a Unicorn environment to ensure certs are then copied to new app instance (not sure strictly necessary if previous QA shows change def works)