### PR TITLE
[TEY-218] Reverts change of Passenger variables to lazy

### DIFF
--- a/cookbooks/passenger5/recipes/install.rb
+++ b/cookbooks/passenger5/recipes/install.rb
@@ -55,18 +55,12 @@ node.engineyard.apps.each_with_index do |app,index|
     group   ssh_username
     mode    0755
     backup  0
-    variables(
-      lazy {
-        {
-          :user         => ssh_username,
-          :app_name     => app.name,
-          :version      => version,
-          :port         => app_base_port,
-          :worker_count => recipe.get_pool_size,
-          :rails_env    => framework_env
-        }
-      }
-    )
+    variables(:user         => ssh_username,
+              :app_name     => app.name,
+              :version      => version,
+              :port         => app_base_port,
+              :worker_count => recipe.get_pool_size,
+              :rails_env    => framework_env)
   end
 
   # Setup log rotate for passenger.log


### PR DESCRIPTION
Description of your patch
-------------
Reverts the change made in https://github.com/engineyard/ey-cookbooks-stable-v6/commit/9506fe2125333b311781f4aabc2e89e244a45bf5#diff-71d9b77ecb60306bb60530e8069e0080 that made the passenger variables lazy in order to get around pre-swap calculation but resulted in multi-app envs having the same passenger port set.

Recommended Release Notes
-------------
Reverts a regression introduced in the last release regarding the ports used for Passenger on multi-app environments.

Estimated risk
-------------
Low - reversion of recipe to previous state.

Components involved
-------------
Passenger recipe.

Description of testing done
-------------
None.

QA Instructions
-------------
None required.