### PR TITLE
[FB-2826] Address default passenger memory limit

### DIFF
--- a/cookbooks/ey-lib/libraries/app_server_configs.rb
+++ b/cookbooks/ey-lib/libraries/app_server_configs.rb
@@ -13,8 +13,8 @@ module AppServerConfigs
 
     def app_server_get_worker_memory_size(app)
       # See https://support.cloud.engineyard.com/entries/23852283-Worker-Allocation-on-Engine-Yard-Cloud for more details
-      # 1. Default value is 255.0
-      mem_size = '255.0'
+      # 1. Default value is 250
+      mem_size = '250'
       # 2. Try to get a value from metadata (this should be removed eventually!)
       mem_size = metadata_app_get_with_default(app.name, :worker_memory_size, mem_size)
       # 3. Try to get a value from the EY environment variable (recommended way)


### PR DESCRIPTION
**Description of your patch**
This is a small patch to fix the default memory of passenger workers along with fixing the monitoring script

**Recommended Release Notes**
Changed default value of passenger to 250 rather than 255

**Estimated risk**

Medium risk - Can cause instance to not function correctly if passenger isn't monitored correctly  

**Components involved**
ey-lib

**Dependencies**
ey-lib

**Description of testing done**
* Booted up new environment under passenger with default value

**QA Instructions**

* Set up environment with custom worker memory values - Check script runs correctly
* Change custom worker memory values to default - Check script runs correctly 
* Boot up new environment - Check script runs correctly
