### PR TITLE
[FB-2827] Fixes unicorn.rb not overwriting correctly

### DIFF
--- a/cookbooks/unicorn/recipes/monit_monitoring.rb
+++ b/cookbooks/unicorn/recipes/monit_monitoring.rb
@@ -43,15 +43,12 @@ node.engineyard.apps.each do |app|
     owner node.engineyard.environment.ssh_username
     group node.engineyard.environment.ssh_username
     mode 0644
+    action :create
     variables(
-      lazy {
-        {
           :unicorn_instance_count => [recipe.get_pool_size / node['dna']['applications'].size, 1].max,
           :app => app.name,
           :type => app.app_type,
           :user => node.engineyard.environment.ssh_username
-        }
-      }
     )
     source "unicorn.rb.erb"
   end
@@ -93,3 +90,4 @@ node.engineyard.apps.each do |app|
     }
   end
 end
+


### PR DESCRIPTION
**Description of your patch**
This is a small patch to fix unicorn.rb not overwriting with new values

**Recommended Release Notes**
Unicorn.rb takes new values on apply if they're set

**Estimated risk**

High risk - Can cause unicorn not to configure if recipe is incorrect

**Components involved**
unicorn

**Dependencies**
unicorn

**Description of testing done**
* Changed values on an environment and hit apply

**QA Instructions**

* Set up environment with custom worker values - Check unicorn.rb values
* Change custom worker values to default or something else - Check unicorn.rb values
* Boot up new environment - Check unicorn.rb has been configured correctly to values for that type of instance / settings
