### PR TITLE
[FB-2828] MySQL certificate files missing on new instance boot

### DIFF
--- a/cookbooks/mysql/templates/default/copycerts.sh.erb
+++ b/cookbooks/mysql/templates/default/copycerts.sh.erb
@@ -1,0 +1,35 @@
+instances='<%= @app %>'
+name='<%= @user %>'
+ssh_options="ssh -i /home/${name}/.ssh/internal -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+
+
+function push_cert {
+  local target=${1}
+#Pushes LE certs
+    rsync -rt -e "${ssh_options}" deploy@${target}:/home/${name}/.mysql /home/${name}
+
+#Make owner is correctly set
+
+chown ${name}:${name} /home/${name}/.mysql -R
+
+}
+
+    
+
+function is_up() {
+  eval ${ssh_options} $1 'date'
+  [[ $? -eq 0 ]]
+}
+
+cd ${keypath}
+# copy keys to other instances
+for instance in ${instances}
+do
+  if is_up ${instance}
+  then
+    push_cert ${instance}
+  else
+    echo "Instance ${instance} is not available. Skipping."
+  fi
+done
+

--- a/cookbooks/ssh_keys/recipes/default.rb
+++ b/cookbooks/ssh_keys/recipes/default.rb
@@ -33,7 +33,7 @@ end
     block do
       keys = [node['dna'][:user_ssh_key]].flatten
       keys << node['dna'][:admin_ssh_key].to_s
-      keys << %|from="#{node.cluster.join(",")}" #{node['dna'][:internal_ssh_public_key]}|.to_s
+      keys << %|from="#{`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ifconfig |grep ether |awk {'print $2'} |grep -v "02:42")/vpc-ipv4-cidr-block`}" #{node['dna'][:internal_ssh_public_key]}|.to_s
 
       File.open("#{ssh_dir}/authorized_keys.tmp", 'w') do |temp_key_file|
         keys.each do |key|


### PR DESCRIPTION
**Description of your patch**

Small but very needed addition to MySQL and SSH_KEYS to allow certificate files to be pulled before the integration step on new instances, SSH_KEYS allow all instances with-in VPC access to SSH if the key is in place rather than specific private IP addresses.

**Recommended Release Notes**
Fixes integration and need of manual input when adding additional application servers when using MySQL certificates 

**Estimated risk**

High risk - Can cause instance to not function correctly due to SSH_KEYS no longer working with the internal key or MySQL certificates being incorrectly copied.

**Components involved**
ssh_keys, mysql

**Dependencies**
ssh_keys, mysql

**Description of testing done**

* Added instance to set up that was already running

**QA Instructions**

* Set up environment in staging / production format followed by booting additional application or utility instance.
* Set up environment in a solo set up followed by booting an additional utility instance 

