### PR TITLE
[FB-3873] Allows NodeJS to be set easily by variables

### DIFF
--- a/EnvironmentVariables.md
+++ b/EnvironmentVariables.md
@@ -21,6 +21,8 @@ If you are missing a setting, please request it by [opening a GitHub issue](http
 | `EY_MEMCACHED_ENABLED`              | `false`       | Sets up Memcached. [More details here](./cookbooks/memcached/README.md#environment-variables)                                                                                                               |
 | `EY_SIDEKIQ_*`                      | N/A           | Sets up Sidekiq. [More details here](./cookbooks/sidekiq/readme.md#environment-variables)                                                                                                                   |
 | `EY_PHP_EXTRA_EXTENSIONS`           | N/A           | Lists (as comma-separated values) additional PHP extensions that should be installed.                                                                                                                       |
+| `EY_NODEJS_VERSION`                   | N/A           | Sets the exact version of NodeJS (e.g. "12.18.3")                                                                                                                                                     |
+
 | [Worker settings](#worker-settings) | N/A           | [See below](#worker-settings)                                                                                                                                                                               |
 
 

--- a/cookbooks/nodejs/attributes/default.rb
+++ b/cookbooks/nodejs/attributes/default.rb
@@ -23,4 +23,4 @@ fallback_nodejs_version = case version
                             '10.17.0'
                           end
 
-default['nodejs']['version'] = node.engineyard.environment.metadata('nodejs_version', fallback_nodejs_version)
+default['nodejs']['version'] = fetch_env_var(node, 'EY_NODEJS_VERSION') || node.engineyard.environment.metadata('nodejs_version', fallback_nodejs_version)


### PR DESCRIPTION
**Description of your patch**

Allows NodeJS to be set by environmental variable 

**Recommended Release Notes**

NodeJS can now be easily set by environmental variable

**Estimated risk**

Low risk - Adding ease of use to v6 rather than overlaying chef .

**Components involved**
NodeJS

**Dependencies**
NodeJS

**Description of testing done**

* Booted an instance
* Set version by UI, after UI set by variable, and meta. Made sure version would change and set variable to be default value if set


**QA Instructions**

* Boot an environment up (any setting)
* Set NodeJS by backend, followed by running an apply
* Check it installed on instance(s)
* Set NodeJS by variable, follow by running an apply
* Check the variable version is installed on the instance
* Remove nodeJS variable, set version either by UI or backend run an apply
* Check NodeJS variable is set to the version set above 