### PR TITLE
[FB-3894] Update puma startup to use --control-url

### DIFF
--- a/cookbooks/puma/templates/default/app_control.erb
+++ b/cookbooks/puma/templates/default/app_control.erb
@@ -118,7 +118,7 @@ start() {
       nohup puma ${threads:+"-t $threads"} \
         --environment ${framework_env} \
         --state ${pid_directory}/puma.$PORT.state \
-        --control unix://${pid_directory}/pumactl.$PORT.sock \
+        --control-url unix://${pid_directory}/pumactl.$PORT.sock \
         --pidfile ${pid_directory}/puma.$PORT.pid \
         --port $PORT \
         $puma_options \


### PR DESCRIPTION
**Description of your patch**

Changes --control to --control-url in puma startup.
The --control option has been removed in puma 5

**Recommended Release Notes**

Add support for puma 5 ?

**Estimated risk**

Low, requires puma 3.12.0 / 2018-07-13

**Components involved**

puma

**Dependencies**

None

**Description of testing done**

none
