### PR TITLE
[FB-3899] Fixes ElasticSearch restarting on apply

### DIFF
--- a/cookbooks/elasticsearch/recipes/start.rb
+++ b/cookbooks/elasticsearch/recipes/start.rb
@@ -1,3 +1,3 @@
 service 'elasticsearch' do
-  action [:restart, :enable]
+  action [:start, :enable]
 end


### PR DESCRIPTION
**Description of your patch**

Fixes restart issue with ElasticSeach when apply is ran

**Recommended Release Notes**

Fixes restart issue with ElasticSearch

**Estimated risk**

Medium risk - ElasticSearch currently can cause downtime when chef is running

**Components involved**
ElasticSearch


**Dependencies**
ElasticSearch

**Description of testing done**

* Created Elasticsearch instance
* Checked ES was running using systemctl
* Pressed apply
* Checked if ES had restarted

* Booted up completely new environment and instance using ES
* Made sure ES had started after boot
* Pressed apply
* Made sure ES hadn't restarted

**QA instructions**

* Create environment
* Set up ElasticSearch
* Press apply once after ElasticSearch is successfully running
* Check if ElasticSearch has been restarted
