### PR TITLE
[FB-3883] Thinking Sphinx 3

### DIFF
--- a/cookbooks/thinking_sphinx_3/README.md
+++ b/cookbooks/thinking_sphinx_3/README.md
@@ -1,0 +1,7 @@
+
+name 'thinking_sphinx_3'
+description 'Configuration & deployment of Thinking Sphinx 3.2.0-1 on Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '6.0.0'

--- a/cookbooks/thinking_sphinx_3/attributes/default.rb
+++ b/cookbooks/thinking_sphinx_3/attributes/default.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: thinking_sphinx_3
+# Attrbutes:: default
+#
+
+default['sphinx'] = {
+  'utility_name' => 'sphinx',
+
+  # The version of sphinxsearch to install on v6
+  # Default: 2.2.11-2
+  'version' => '2.2.11-2',
+  
+  # Applications that use sphinx
+  # Default: all applications on the environment
+  'applications' => node['dna']['applications'].map{|app_name, data| app_name},
+  
+  # Index frequency. How often the indexer cron job runs
+  # Default: 15 (minutes)
+  'frequency' => 15
+}
+
+# True if the recipe should run on the instance
+# Default: true on a solo instance or a utility instance named 'sphinx'
+default['sphinx']['is_thinking_sphinx_instance'] = node['dna']['instance_role'] == 'util' && node['dna']['name'] == default['sphinx']['utility_name']
+
+# Sphinx host
+# Default: hostname of the 'sphinx' utility instance
+util = node['dna']['engineyard']['environment']['instances'].find{|i| i[:name].to_s == default['sphinx']['utility_name']}
+Chef::Log.info "SPHINX INSTANCE: #{util.inspect}"
+
+default['sphinx']['host'] = util ? util['private_hostname'] : '127.0.0.1'
+Chef::Log.info "SPHINX HOST: #{default['sphinx']['host']}"

--- a/cookbooks/thinking_sphinx_3/metadata.rb
+++ b/cookbooks/thinking_sphinx_3/metadata.rb
@@ -1,0 +1,6 @@
+name 'thinking_sphinx_3'
+description 'Configuration & deployment of Thinking Sphinx 3 on Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '5.0.0'

--- a/cookbooks/thinking_sphinx_3/recipes/cleanup.rb
+++ b/cookbooks/thinking_sphinx_3/recipes/cleanup.rb
@@ -1,0 +1,34 @@
+#
+# Cookbook Name:: thinking_sphinx_3
+# Recipe:: cleanup
+#
+
+# Clean up sphinx on non-sphinx instances but not on db instances
+if !node['sphinx']['is_thinking_sphinx_instance'] && !['db_master', 'db_slave'].include?(node['dna']['instance_role'])
+ 
+    # report to dashboard
+    ey_cloud_report "sphinx" do
+      message "Cleaning up sphinx (if needed)"
+    end
+    
+    # loop through applications
+    node['dna']['applications'].each do |app_name, _|
+      # monit
+      file "/etc/monit.d/sphinx_#{app_name}.monitrc" do 
+        action :delete
+        notifies :run, resources(:execute => "reload-monit")
+        only_if "test -f /etc/monit.d/sphinx_#{app_name}.monitrc"
+      end
+    
+      # remove cronjob
+      cron "indexer-#{app_name}" do
+        action :delete
+      end
+    end 
+  
+    # stop sphinx
+    execute "kill-sphinx" do
+      command "pkill -f searchd"
+      only_if "pgrep -f searchd"
+    end
+end

--- a/cookbooks/thinking_sphinx_3/recipes/default.rb
+++ b/cookbooks/thinking_sphinx_3/recipes/default.rb
@@ -1,0 +1,9 @@
+#
+# Cookbook Name:: thinking_sphinx_3
+# Recipe:: default
+#
+
+include_recipe "thinking_sphinx_3::cleanup"
+include_recipe "thinking_sphinx_3::install"
+include_recipe "thinking_sphinx_3::thinking_sphinx"
+include_recipe "thinking_sphinx_3::setup"

--- a/cookbooks/thinking_sphinx_3/recipes/install.rb
+++ b/cookbooks/thinking_sphinx_3/recipes/install.rb
@@ -10,7 +10,7 @@ if node['sphinx']['is_thinking_sphinx_instance']
     end
   
     # install package
-    package "ruby-thinking-sphinx" do
+    package "sphinxsearch" do
       version node['sphinx']['version']
       action :install
     end

--- a/cookbooks/thinking_sphinx_3/recipes/install.rb
+++ b/cookbooks/thinking_sphinx_3/recipes/install.rb
@@ -1,0 +1,17 @@
+#
+# Cookbook Name:: thinking_sphinx_3
+# Recipe:: install
+#
+
+if node['sphinx']['is_thinking_sphinx_instance']
+    # report to dashboard
+    ey_cloud_report "sphinx" do
+      message "Installing sphinx"
+    end
+  
+    # install package
+    package "ruby-thinking-sphinx" do
+      version node['sphinx']['version']
+      action :install
+    end
+end

--- a/cookbooks/thinking_sphinx_3/recipes/setup.rb
+++ b/cookbooks/thinking_sphinx_3/recipes/setup.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: thinking_sphinx_3
+# Recipe:: setup
+#
+
+if node['sphinx']['is_thinking_sphinx_instance'] 
+    # report to dashboard
+    ey_cloud_report "sphinx" do
+      message "Setting up sphinx"
+    end
+    
+    node['sphinx']['applications'].each do |app_name|
+      # monit
+      execute "restart-sphinx-#{app_name}" do
+        command "monit reload && sleep 2s && monit restart sphinx_#{app_name}"
+        action :nothing
+      end
+      
+      # setup monit for each app defined (see attributes)
+      template "/etc/monit.d/sphinx_#{app_name}.monitrc" do
+        source "sphinx.monitrc.erb"
+        owner node['owner_name']
+        group node['owner_name']
+        mode "0644"
+        backup 0
+        variables({
+          :environment => node['dna']['environment']['framework_env'],
+          :user => node[:owner_name],
+          :pid_file => "/data/#{app_name}/shared/log/#{node['dna']['environment']['framework_env']}.sphinx.pid",
+          :app_name => app_name
+        })
+        notifies :run, resources(:execute => "restart-sphinx-#{app_name}")
+      end
+  
+      # indexer cron job
+      if node['sphinx']['frequency'].to_i > 0
+        cron "indexer-#{app_name}" do
+          command "/usr/bin/indexer -c /data/#{app_name}/current/config/#{node['dna']['environment']['framework_env']}.sphinx.conf --all --rotate"
+          minute "*/#{node['sphinx']['frequency']}"
+          user node['owner_name']
+        end
+      end
+    end
+  end

--- a/cookbooks/thinking_sphinx_3/recipes/setup.rb
+++ b/cookbooks/thinking_sphinx_3/recipes/setup.rb
@@ -42,3 +42,28 @@ if node['sphinx']['is_thinking_sphinx_instance']
       end
     end
   end
+
+  # added after sidekiq analysis
+
+if node['sphinx']['create_restart_hook']
+  # loop through applications
+  node['dna']['applications'].each do |app_name, _|
+    directory "/data/#{app_name}/shared/hooks/sphinx" do
+      owner node["owner_name"]
+      group node["owner_name"]
+      mode 0755
+      recursive true
+    end
+
+    # after_restart hook
+    template "/data/#{app_name}/shared/hooks/sphinx/after_restart" do
+      mode 0755
+      source "after_restart.erb"
+      backup false
+      variables({
+        :thinking_sphinx_group       => "#{app_name}_sphinx",
+        :is_thinking_sphinx_instance => node['sphinx']['is_thinking_sphinx_instance']
+      })
+    end
+  end
+end

--- a/cookbooks/thinking_sphinx_3/recipes/thinking_sphinx.rb
+++ b/cookbooks/thinking_sphinx_3/recipes/thinking_sphinx.rb
@@ -1,0 +1,92 @@
+#
+# Cookbook Name:: thinking_sphinx_3
+# Recipe:: thinking_sphinx
+#
+
+# create config/thinking_sphinx.yml on all application and utility instances
+if ['app_master', 'app', 'solo', 'util'].include?(node['dna']['instance_role'])
+
+    # setup thinking sphinx on each app (see attributes)
+    node['sphinx']['applications'].each do |app_name|
+      # variables
+      current_path = "/data/#{app_name}/current"
+      shared_path = "/data/#{app_name}/shared"
+      env = node['dna']['environment']['framework_env']
+      
+      # config yml
+      template "#{shared_path}/config/thinking_sphinx.yml" do
+        source "thinking_sphinx.yml.erb"
+        owner node['owner_name']
+        group node['owner_name']
+        mode "0644"
+        backup 0
+        variables({
+          :environment => env,
+          :address => node['sphinx']['host'],
+          :pid_file => "#{shared_path}/log/#{env}.sphinx.pid"
+        })
+      end
+  
+      #symlink config yml
+      link "#{current_path}/config/thinking_sphinx.yml" do
+        to "#{shared_path}/config/thinking_sphinx.yml"
+        only_if { File.exist?("#{current_path}/config") }
+      end
+  
+    end
+  end
+  
+  # set up sphinx directory and run ts:config
+  # on sphinx instances only
+  if node['sphinx']['is_thinking_sphinx_instance']
+    # install bundler if not present
+    gem_package "bundler" do
+      action :install
+      not_if "gem list | grep bundler"
+    end
+  
+    node['sphinx']['applications'].each do |app_name|
+      # variables
+      current_path = "/data/#{app_name}/current"
+      shared_path = "/data/#{app_name}/shared"
+      env = node['dna']['environment']['framework_env']
+      
+      # create sphinx directory
+      directory "#{shared_path}/sphinx" do
+        owner node[:owner_name]
+        group node[:owner_name]
+      end
+      
+      # remove sphinx dir
+      directory "#{current_path}/db/sphinx" do
+        action :delete
+        recursive true
+        only_if "test -d #{current_path}/db/sphinx"
+      end
+    
+      # symlink
+      link "#{current_path}/db/sphinx" do
+        to "#{shared_path}/sphinx"
+        only_if { File.exist?("#{current_path}/db") }
+      end
+    
+      # ts:configure already runs on a deploy hook
+      # if File.symlink?(current_path)
+      #   # configure thinking sphinx
+      #   execute "configure sphinx" do 
+      #     command "cd #{current_path} && bundle exec rake ts:configure"
+      #     user node['owner_name']
+      #     environment 'RAILS_ENV' => env
+      #   end
+      # else
+      #   Chef::Log.info "Thinking Sphinx was not configured because the application (#{app_name}) must be deployed first. Please deploy your application and then re-run the custom chef recipes."
+      # end
+      #
+      # don't index on every chef run
+      # execute "indexing" do
+      #   command "cd #{current_path} && bundle exec rake ts:index"
+      #   user node['owner_name']
+      #   environment 'RAILS_ENV' => env
+      # end
+    end
+  end

--- a/cookbooks/thinking_sphinx_3/templates/default/after_restart.erb
+++ b/cookbooks/thinking_sphinx_3/templates/default/after_restart.erb
@@ -1,0 +1,6 @@
+<% if @is_thinking_sphinx_instance == true %>
+sudo monit -g <%= @thinking_sphinx_group %> restart all
+<% else %>
+# This instance doesn't have Thinking Sphinx workers set up. Performing a NoOp.
+exit 0
+<% end %>

--- a/cookbooks/thinking_sphinx_3/templates/default/sphinx.monitrc.erb
+++ b/cookbooks/thinking_sphinx_3/templates/default/sphinx.monitrc.erb
@@ -1,0 +1,5 @@
+check process sphinx_<%= @app_name %>
+  with pidfile <%= @pid_file %>
+  start program = "/usr/bin/searchd --pidfile --config /data/<%= @app_name %>/current/config/<%= @environment %>.sphinx.conf" as uid <%= @user %> and gid <%= @user %>
+  stop program = "/usr/bin/searchd --stopwait --config /data/<%= @app_name %>/current/config/<%= @environment %>.sphinx.conf" as uid <%= @user %> and gid <%= @user %>
+  group sphinx_<%= @app_name %>

--- a/cookbooks/thinking_sphinx_3/templates/default/thinking_sphinx.yml.erb
+++ b/cookbooks/thinking_sphinx_3/templates/default/thinking_sphinx.yml.erb
@@ -1,0 +1,4 @@
+<%= @environment %>:
+  address: <%= @address %>
+  mem_limit: 128M
+  pid_file: <%= @pid_file %>

--- a/custom-cookbooks/thinking_sphinx_3/README.md
+++ b/custom-cookbooks/thinking_sphinx_3/README.md
@@ -1,0 +1,6 @@
+# Sphinx
+
+This example contains a complete cookbooks/ that you can use on the stable-v5 stack.
+
+See https://github.com/engineyard/ey-cookbooks-stable-v6/tree/next-release/custom-cookbooks/thinking_sphinx_3/cookbooks/custom-thinking_sphinx_3 for complete instructions.
+

--- a/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/README.md
+++ b/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/README.md
@@ -1,0 +1,125 @@
+# Custom Sphinx
+
+The thinking_sphinx_3 recipe installs sphinx, creates a monit config file, and creates thinking_sphinx.yml.
+
+You need to add the thinking-sphinx and mysql2 gems. You need mysql2 even if you're using postgres as your database.
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+Our main recipes have the `thinking_sphinx_3` recipe but it does not run by default. To run the `thinking_sphinx_3` recipe, you should copy this recipe `custom-thinking_sphinx_3`. You should not copy the actual `thinking_sphinx_3` recipe. That is managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+      ```ruby
+      include_recipe 'custom-thinking_sphinx_3'
+      ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+      ```ruby
+      depends 'custom-thinking_sphinx_3'
+      ```
+
+    If you do not have `cookbooks/ey-custom` on your app repository, you can copy `custom-cookbooks/thinking_sphinx_3/cookbooks/ey-custom` from the next step to `/path/to/app/cookbooks`.
+
+3. Copy `custom-cookbooks/thinking_sphinx_3/cookbooks/custom-thinking_sphinx_3` to `cookbooks/`
+
+      ```
+      cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+      git clone https://github.com/engineyard/ey-cookbooks-stable-v6
+      cd ey-cookbooks-stable-v6
+      cp custom-cookbooks/thinking_sphinx_3/cookbooks/custom-thinking_sphinx_3 /path/to/app/cookbooks/
+      ```
+
+4. Download the ey-core gem on your local machine and upload the recipes
+
+      ```
+      gem install ey-core
+      ey-core recipes upload --environment=<nameofenvironment> --file=<pathtocookbooksfolder> --apply
+      ```
+
+5. Add a deploy hook to your application. Create the `deploy/` directory if it doesn't exist.
+
+      ```ruby
+      # deploy/after_symlink.rb
+      on_utilities('sphinx') do
+        run "[[ -d #{config.shared_path}/sphinx ]] && ln -nfs #{config.shared_path}/sphinx #{config.current_path}/db/sphinx"
+        run "cd #{config.current_path} && RAILS_ENV=#{config.environment} bundle exec rake ts:configure"
+      end
+      ```
+
+    See our [Deploy Hook](https://engineyard.zendesk.com/entries/21016568-use-deploy-hooks) documentation for more information on using deploy hooks.
+
+## Customizations
+
+All customizations go to `cookbooks/custom-thinking_sphinx_3/attributes/default.rb`.
+
+### Choose the instance that run the recipe
+
+By default, the thinking_sphinx_3 recipe runs on a utility instance named `sphinx`. You can change this by setting `default['sphinx']['utility_name'] `. For advanced users, you can run sphinx on non-util instances by using `node['dna']['instance_role']`. 
+
+```ruby
+# this is the default
+default['sphinx']['utility_name'] = 'sphinx'
+
+# run sphinx on a utility instance named search
+default['sphinx']['utility_name'] = 'search'
+
+# run the recipe on a solo instance
+# you need to add 2 lines
+default['sphinx']['utility_name'] = 'this_will_not_match_a_util'
+default['sphinx']['is_thinking_sphinx_instance'] = (node['dna']['instance_role'] == 'solo')
+```
+
+### Choose the applications that run sphinx
+
+By default, we create sphinx.yml and monitrc for all applications. This works if you only have one application on the environment. Running multiple sphinx processes is not supported. If you have more than one application on the environment, you must choose one application.
+
+```ruby
+# this is the default
+# get all applications
+default['sphinx']['applications'] = node['dna']['applications'].map{|app_name, data| app_name}
+
+# specify the application name 
+default['sphinx']['applications'] = ['todo']
+```
+
+### Choose the sphinx version
+
+```ruby
+# this is the default
+default['sphinx']['version'] = '2.1.9'
+
+# specify a new version
+# run apt-cache policy sphinx on the instance to get possible values
+default['sphinx']['version'] = '2.2.10'
+```
+
+### Choose the frequency of the indexer cron job
+
+You need to reindex regularly. The recipe adds a cron job for the `indexer` command.
+
+```ruby
+# the default is reindex every 15 minutes
+default['sphinx']['frequency'] = 15
+
+# change it to 60 minutes
+default['sphinx']['frequency'] = 60
+```
+
+### Run sphinx on every app instance
+
+By default, sphinx runs on one utility instance only. This makes it a single point of failure. You can run sphinx on every app instance and let each app instance connect to localhost.
+
+The advantage is if an app instance goes down, search will still work. The disadvantages are 1) you have to reindex on each app instance, which can overload your database, 2) your utility instances won't have access to search, and 3) you have to manage multiple sphinx processes which all do the same thing.
+
+You have to add all 3 lines
+
+```ruby
+default['sphinx']['utility_name'] = 'this_will_not_match_a_util'
+default['sphinx']['is_thinking_sphinx_instance'] = ['app_master', 'app'].include?(node['dna']['instance_role'])
+default['sphinx']['host'] = '127.0.0.1'
+```

--- a/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/README.md
+++ b/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/README.md
@@ -91,7 +91,7 @@ default['sphinx']['applications'] = ['todo']
 
 ```ruby
 # this is the default
-default['sphinx']['version'] = '2.1.9'
+default['sphinx']['version'] = '2.2.11-2'
 
 # specify a new version
 # run apt-cache policy sphinx on the instance to get possible values

--- a/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/attributes/default.rb
+++ b/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/attributes/default.rb
@@ -1,0 +1,4 @@
+# default['sphinx']['utility_name'] = 'sphinx'
+# default['sphinx']['applications'] = ['todo']
+# default['sphinx']['version'] = '3.2.0-1'
+# default['sphinx']['frequency'] = 15

--- a/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/attributes/default.rb
+++ b/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/attributes/default.rb
@@ -1,4 +1,4 @@
 # default['sphinx']['utility_name'] = 'sphinx'
 # default['sphinx']['applications'] = ['todo']
-# default['sphinx']['version'] = '3.2.0-1'
+# default['sphinx']['version'] = '2.2.11-2'
 # default['sphinx']['frequency'] = 15

--- a/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/metadata.rb
+++ b/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/metadata.rb
@@ -1,0 +1,3 @@
+name 'custom-thinking_sphinx_3'
+
+depends 'thinking_sphinx_3'

--- a/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/recipes/default.rb
+++ b/custom-cookbooks/thinking_sphinx_3/custom-thinking_sphinx_3/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'thinking_sphinx_3' 

--- a/custom-cookbooks/thinking_sphinx_3/ey-custom/metadata.rb
+++ b/custom-cookbooks/thinking_sphinx_3/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom-thinking_sphinx_3'

--- a/custom-cookbooks/thinking_sphinx_3/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/thinking_sphinx_3/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe 'custom-thinking_sphinx_3'


### PR DESCRIPTION
Description of your patch
-------------
Thinking Sphinx cookbooks for stack-v6. Involves customized installation of `sphinxsearch` and configuration on Ubuntu based v6 distribution.

Recommended Release Notes
-------------
Adds Thinking Sphinx integration to Stack-v6

Estimated risk
-------------
Low, This is a feature. 

Components involved
-------------
`Thinking_Sphinx_3` cookbook and `Custom-Thinking_Sphinx_3` cookbook

Dependencies
-------------
None

Description of testing done
-------------
1. Booted a multi-environment with a `util` instance named `sphinx`
2. Used custom ThinkingSphinx3 cookbook and setup installation within the util instance.
3. Re-deployed the application
4. Verified if Thinking Sphinx workers are running.

QA Instructions
-------------

**Scenario 1**
1. Boot a solo instance plus a util instance named `sphinx`
2. Upload the custom recipes and redeploy
3. Make sure the deployment is successful and Check if ThinkingSpinx workers are running.

**Scenario 2**
1. Boot a multi environment with a custom util instance with any compatible name except `sphinx`
2. Upload the custom recipes and redeploy
3. Make sure the deployment is successful and Check if ThinkingSphinx worker are running
