### PR TITLE
[FB-5013] Skip database SSL push on RDS environments

### DIFF
--- a/cookbooks/mysql/recipes/install.rb
+++ b/cookbooks/mysql/recipes/install.rb
@@ -50,7 +50,7 @@ end
 
 package "libmysqlclient-dev"
 
-if !node['dna']['instance_role'][/^(solo)/]
+if !node['dna']['instance_role'][/^(solo)/] and !db_host_is_rds?
 
   managed_template "/engineyard/bin/mysqlcopycerts.sh" do
     owner 'root'


### PR DESCRIPTION
Description of your patch
-------------
Database SSL push does not apply to RDS environments.

Recommended Release Notes
-------------
Skip database SSL push on RDS environments

Estimated risk
-------------
Low

Components involved
-------------
MySQL cookbook

Description of testing done
-------------
Tested on mysql_5x, no_db, and amazon_rds environments

QA Instructions
-------------
### Scenario 1
1. Boot mysql_5x environment
2. Make sure the chef is successful and the environment is green

### Scenario 2
1. Boot no_db environment
2. Make sure the chef is successful and the environment is green

### Scenario 3
1. Boot amazon_rds environment
2. Make sure the chef is successful and the environment is green

