### PR TITLE
[FB-5080] Install PostgreSQL additional modules

### DIFF
--- a/cookbooks/postgresql/templates/default/install.sh.erb
+++ b/cookbooks/postgresql/templates/default/install.sh.erb
@@ -6,7 +6,14 @@ get_full_pkg_version() {
   echo "$(apt-cache show ${postgres_package}=${package_version}* | grep 'Version:' | awk '{print $2}' 2>/dev/null)"
 }
 
-<% packages = ["postgresql-client-#{@postgres_version}", "postgresql-#{@postgres_version}", "postgresql-server-dev-#{@postgres_version}"] %>
+<%
+if @postgres_version=="9.5" || @postgres_version=="9.6"
+  packages = ["postgresql-client-#{@postgres_version}", "postgresql-#{@postgres_version}", "postgresql-server-dev-#{@postgres_version}", "postgresql-contrib-#{@postgres_version}"] 
+else
+  packages = ["postgresql-client-#{@postgres_version}", "postgresql-#{@postgres_version}", "postgresql-server-dev-#{@postgres_version}"]
+end
+%>
+
 <% packages.each do |package| %>
 # Get the full version for the package <%= package %>
 PKG_VER="$(get_full_pkg_version "<%= package %>" "<%= @package_version %>")"


### PR DESCRIPTION
Description of your patch
-------------
Installs the PostgreSQL additional modules on postgres_95 and postgres_96 databases.

Recommended Release Notes
-------------
Installs the PostgreSQL additional modules on PostgreSQL 9.5 and PostgreSQL 9.6 databases. 

Estimated risk
-------------
Low

Components involved
-------------
postgres_95, postgres_96, postgres_10, postgres_11

Description of testing done
-------------
This has been tested with postgres_95, postgres_96, postgres_10, postgres_11.

QA Instructions
-------------
* Boot postgres_95 environment(It can be a solo or a clustered environment). 
* Enable hstore extension

```
cat << EOF > /db/postgresql/extensions.json     
{
  "database_name": ["hstore"]
}
EOF
```

* Run chef
* Check if it was enabled

```
psql <database_name> -c "\dx"
```

* Run the above steps postgres_96, postgres_10 and postgres_11