### PR TITLE
Fix generated ssh authorized_keys file on docker instances

### DIFF
--- a/cookbooks/ssh_keys/recipes/default.rb
+++ b/cookbooks/ssh_keys/recipes/default.rb
@@ -33,7 +33,7 @@ end
     block do
       keys = [node['dna'][:user_ssh_key]].flatten
       keys << node['dna'][:admin_ssh_key].to_s
-      keys << %|from="#{`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ifconfig |grep ether |awk {'print $2'} |grep -v "02:42")/vpc-ipv4-cidr-block`}" #{node['dna'][:internal_ssh_public_key]}|.to_s
+      keys << %|from="#{`curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$(ifconfig |grep -m 1 "ether\s.*\stxqueuelen\s[1-9][0-9]*" |awk {'print $2'} |grep -v "02:42")/vpc-ipv4-cidr-block`}" #{node['dna'][:internal_ssh_public_key]}|.to_s
 
       File.open("#{ssh_dir}/authorized_keys.tmp", 'w') do |temp_key_file|
         keys.each do |key|


### PR DESCRIPTION
Docker instances have multiple ethernet interfaces so the script needed updated to identify the physical ethernet adapter. Physical ethernet interfaces have a txqueuelen > 0. This update fixes the entry in authorized_keys and allows deployments to succeed.