### PR TITLE
[FB6657] ephemeraldisk recipe update to avoid reboot failures

### DIFF
--- a/cookbooks/ephemeraldisk/libraries/ephemeral_helpers.rb
+++ b/cookbooks/ephemeraldisk/libraries/ephemeral_helpers.rb
@@ -60,6 +60,7 @@ module EphemeralHelpers
       fstype "ext4"
       device device
       action [:mount, :enable]
+      options "defaults nofail"
     end
   end
 end


### PR DESCRIPTION
**Description of your patch**

Fixes the instance reboot issue where it will refuse to start or start in maintenance mode.

**Recommended Release Notes**

Fixes fstab formatting for ephemeral disks

**Estimated risk**

Medium risk - Without a fix instances with ephemeral disks mounted can not safely be restarted without manual intervention afterwards

**Components involved**
ephemeraldisk

**Dependencies**
ephemeraldisk

**Description of testing done**

* Reboot an instance with ephemeral disks mounted

**QA Instructions**

* Boot an instance which utilises ephemeral disk
* SSH into instance
* Make sure its mounted using `df -h`
* Check fstab `cat /etc/fstab` 
* Make sure its mounted with nofail
* Reboot instance
* Ensure instance restarts correctly
