### PR TITLE
Adds ca-certs to the recipes

### DIFF
--- a/cookbooks/openssl/recipes/default.rb
+++ b/cookbooks/openssl/recipes/default.rb
@@ -2,3 +2,8 @@
 package 'openssl' do
   action :install
 end
+
+#Install Certificates
+execute 'install-ca-certs' do
+  command "apt-get -q -y install ca-certificates"
+end


### PR DESCRIPTION
Description of your patch
-------------
1. Adds `ca-certificates` package to chef to keep certificates up to date

Recommended Release Notes
-------------
Updated system certificates

Estimated risk
-------------
Moderate/High - Is required to avoid errors with external sources using X1 LetsEncrypt

Components involved
-------------
1. `openssl` chef recipe 

Dependencies
-------------
None

Description of testing done
-------------
* Created environment
* Booted up solo instance



QA Instructions
-------------

* Create environment under postgres
* Boot up instances either solo or multi-instances
* Ensure chef runs correctly and entirely