### PR TITLE
[FB-10196] adding missing config for multiple queues per worker

### DIFF
--- a/custom-cookbooks/sidekiq/cookbooks/custom-sidekiq/README.md
+++ b/custom-cookbooks/sidekiq/cookbooks/custom-sidekiq/README.md
@@ -143,6 +143,21 @@ Monit keeps track of your Sidekiq workers and by default, it restarts workers ex
 default['sidekiq']['worker_memory'] = 450
 ```
 
+### Configure multiple queues per worker
+
+By default the recipe configures a single queue named 'Default' per every worker put in place.  The config below shows how to configure more than one queue per worker, and specify their priority as well:
+
+```ruby
+  # Queues
+  sidekiq['queues'] = {
+    # :queue_name => priority
+    :default => 1,
+    :high => 10,
+    :medium => 5,
+    :low => 2
+  }
+```
+
 ## Restarting your workers
 
 This recipe does NOT restart your workers. The reason for this is that shipping


### PR DESCRIPTION
Description of your patch
-------------
adding missing config for multiple queues per worker (same as v5)

Recommended Release Notes
-------------
document multiple queues per worker

Estimated risk
-------------
low (readme change)

Components involved
-------------
na

Description of testing done
-------------
no testing required, only readme changed, usage already proven to work in customer zd ticket https://engineyard.zendesk.com/agent/tickets/183126

QA Instructions
-------------
no QA required
