### PR TITLE
Trim white spaces & newlines from env vars

### DIFF
--- a/cookbooks/ey-lib/libraries/env_vars.rb
+++ b/cookbooks/ey-lib/libraries/env_vars.rb
@@ -7,7 +7,7 @@ module EnvVars
       return [] unless metadata && metadata['environment_variables']
 
       variables = metadata['environment_variables'].map do |var_hash|
-        { :name => var_hash['name'], :value => ::Base64.strict_decode64(var_hash['value']) }
+        { :name => var_hash['name'], :value => ::Base64.strict_decode64(var_hash['value'].squish) }
       end
     end
 


### PR DESCRIPTION
Example:

```
irb(main):014:0> " space-between with space ".squish
=> "space-between with space"
irb(main):015:0> " first line \n 2nd line".squish
=> "first line 2nd line"
irb(main):016:0> " two newlines \n\n".squish
=> "two newlines"
```

References:
- Squish method: https://github.com/rubyworks/facets/blob/master/lib/core/facets/string/squish.rb