### PR TITLE
cookbok-for-elasticache-redis-fbz-10238

### DIFF
--- a/cookbooks/elasticache-redis/README.md
+++ b/cookbooks/elasticache-redis/README.md
@@ -1,0 +1,25 @@
+## Optional Cookbook for Engine Yard Cloud
+
+# Elasticache Redis
+
+AWS Elasticache is managed service for Redis. 
+
+## Overview
+
+This cookbook generates configuration file from provided environment variables.
+
+## Installation
+
+### Environment Variables
+
+When the environment variable `EY_ELASTICACHE_REDIS_ENABLED` is set to "true", this recipe will be enabled and setup up Redis configuration file.
+`EY_ELASTICACHE_REDIS_URL` vairable will be used for the URL
+
+
+### Custom Chef
+
+Since this is an optional recipe, it can be installed by simply including it via a `depends` in your `ey-custom/metadata.rb` file and an `include_recipe` in the appropriate hook file. 
+
+## Notes
+
+1. This recipe will put in place a `redis.yml` on `/data/{app_name}/shared/config/`.

--- a/cookbooks/elasticache-redis/attributes/default.rb
+++ b/cookbooks/elasticache-redis/attributes/default.rb
@@ -1,0 +1,3 @@
+default['elasticache-redis']['ey_elastic_redis_enabled'] = fetch_env_var(node, "EY_ELASTICACHE_REDIS_ENABLED")
+default['elasticache-redis']['ey_elastic_redis_url']     = fetch_env_var(node, "EY_ELASTICACHE_REDIS_URL")
+default['elasticache-redis']['ey_redis']                 = fetch_env_var(node, "EY_REDIS_ENABLED")

--- a/cookbooks/elasticache-redis/metadata.rb
+++ b/cookbooks/elasticache-redis/metadata.rb
@@ -1,0 +1,8 @@
+name 'elasticache-redis'
+description 'Configuration of Elasticache Redis on AWS'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '1.0.1'
+issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v6/issues'
+source_url 'https://github.com/engineyard/ey-cookbooks-stable-v6'

--- a/cookbooks/elasticache-redis/recipes/configure.rb
+++ b/cookbooks/elasticache-redis/recipes/configure.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: redis
+# Recipe:: configure
+#
+
+if node['elasticache-redis']['ey_elastic_redis_enabled']
+
+  if node['elasticache-redis']['ey_redis']
+    raise "ERROR both EY_REDIS and EY_ELASTICACHE_REDIS_ENABLED Enabled"
+  end
+
+  if node['elasticache-redis']['ey_elastic_redis_url'].nil? || node['elasticache-redis']['ey_elastic_redis_url'].empty?
+    raise "ERROR EY_ELASTICACHE_REDIS_URL not Set"
+  end
+
+  Chef::Log.info("Conofiguring Redis (redis.yml) for elasticache-redis")
+
+  if ['solo', 'app', 'app_master'].include?(node['dna']['instance_role'])
+
+    node['dna']['applications'].each do |app, data|
+      template "/data/#{app}/shared/config/redis.yml"do
+        source 'redis.yml.erb'
+        owner node['owner_name']
+        group node['owner_name']
+        mode 0655
+        backup 0
+        variables({
+          'environment' => node['dna']['engineyard']['environment']['framework_env'],
+          'hostname' => node['elasticache-redis']['ey_elastic_redis_url']
+        })
+      end
+    end
+
+  end
+
+end

--- a/cookbooks/elasticache-redis/recipes/default.rb
+++ b/cookbooks/elasticache-redis/recipes/default.rb
@@ -1,0 +1,5 @@
+#
+# Cookbook Name:: elasticache-redis
+#
+
+include_recipe 'elasticache-redis::configure'

--- a/cookbooks/elasticache-redis/templates/default/redis.yml.erb
+++ b/cookbooks/elasticache-redis/templates/default/redis.yml.erb
@@ -1,0 +1,3 @@
+<%= @environment %>:
+  host: <%= @hostname %>
+  port: 6379

--- a/cookbooks/ey-base/metadata.rb
+++ b/cookbooks/ey-base/metadata.rb
@@ -28,6 +28,7 @@ depends 'efs'
 
 # custom recipes
 depends 'redis'
+depends 'elasticache-redis'
 depends 'memcached'
 depends 'sidekiq'
 depends 'letsencrypt'

--- a/cookbooks/ey-base/recipes/custom.rb
+++ b/cookbooks/ey-base/recipes/custom.rb
@@ -2,6 +2,10 @@ if fetch_env_var(node, "EY_REDIS_ENABLED") =~ /^TRUE$/i
   include_recipe 'redis'
 end
 
+if fetch_env_var(node, "EY_ELASTICACHE_REDIS_ENABLED") =~ /^TRUE$/i
+  include_recipe 'elasticache-redis'
+end
+
 if fetch_env_var(node, "EY_MEMCACHED_ENABLED") =~ /^TRUE$/i
   include_recipe 'memcached'
 end


### PR DESCRIPTION
Description of your patch
-------------
PR adds cookbook to configure elasticache redis on EYC, the cookbook added is named "elasticache-redis" which can be configured using environment variables EY_ELASTICACHE_REDIS_ENABLED , EY_ELASTICACHE_REDIS_URL

the cookbook creates config/redis.yml file as output
FBZ : https://t3.fogbugz.com/f/cases/10238/Enable-apps-to-use-ElastiCache-Redis

Recommended Release Notes
-------------
New Recipe : elasticache-redis : adds ability to configure redis.yml from environment variables

Estimated risk
-------------
Low

Components involved
-------------
Environment Variables/Chef

Dependencies
-------------
NA

Description of testing done
-------------
Tested to verify recipe generates config/redis.yml with correct values as set in environment variables
further testing/implementation to be done for ZD #183191


QA Instructions
-------------
Recipe required environment variables set
1. EY_ELASTICACHE_REDIS_ENABLED set to true
2. EY_ELASTICACHE_REDIS_URL set to redis endpoint without port
3. EY_REDIS_ENABLED should not be set to true
