### PR TITLE
[FBZ-10372] env var to override invalid HAProxy vhosts

### DIFF
--- a/cookbooks/haproxy/README.md
+++ b/cookbooks/haproxy/README.md
@@ -2,3 +2,7 @@ haproxy
 ========
 
 Installs and configures haproxy for application server instances (app and app_master).
+
+Environment Variable :
+
+EY_HEALTHCHECK_DOMAIN_OVERRIDE : By Default this recipe picks up first entry from nginx vhost. This ENV can be used to override the health-check domain in case there are wildcrd/reged in nginx vhosts

--- a/cookbooks/haproxy/recipes/configure.rb
+++ b/cookbooks/haproxy/recipes/configure.rb
@@ -48,6 +48,7 @@ end
 
 # FBZ 10372
 healthcheck_domain_override = fetch_env_var(node, 'EY_HEALTHCHECK_DOMAIN_OVERRIDE') || false
+Chef::Log.info "healthcheck_domain_override: #{healthcheck_domain_override}"
 if healthcheck_domain_override
 	haproxy_httpchk_host = healthcheck_domain_override
 end

--- a/cookbooks/haproxy/recipes/configure.rb
+++ b/cookbooks/haproxy/recipes/configure.rb
@@ -46,6 +46,12 @@ unless haproxy_httpchk_path
   end
 end
 
+# FBZ 10372
+healthcheck_domain_override = fetch_env_var(node, 'EY_HEALTHCHECK_DOMAIN_OVERRIDE') || false
+if healthcheck_domain_override
+	haproxy_httpchk_host = healthcheck_domain_override
+end
+
 managed_template "/etc/haproxy.cfg" do
   owner 'root'
   group 'root'


### PR DESCRIPTION
Description of your patch
-------------
PR adds environment variable "EY_HEALTHCHECK_DOMAIN_OVERRIDE" to be use by haproxy recipe

FBZ : https://t3.fogbugz.com/f/cases/10372/

Recommended Release Notes
-------------
Adds "EY_HEALTHCHECK_DOMAIN_OVERRIDE" which can be used to tel haproxy which domain to use for health-checks if the nginx vhost entry contains multiple entries or if the first entry contains wildcard/regex

Estimated risk
-------------
Low

Components involved
-------------
Environment Variables/Chef

Dependencies
-------------
NA

Description of testing done
-------------
Tested to verify recipe uses the domain set in environment for health-checks

QA Instructions
-------------
Recipe required environment variables set
1. EY_HEALTHCHECK_DOMAIN_OVERRIDE : to a valid domain hosted on the environment
2. Verify "haproxy.cfg" is correctly using the set domain.
