### PR TITLE
[FB-2829] Extended keep file support on nginx Re-#189

### DIFF
--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -136,7 +136,7 @@ end
 
 
   if node.engineyard.environment.ruby?
-    template "/data/nginx/servers/#{app.name}.conf" do
+    managed_template "/data/nginx/servers/#{app.name}.conf" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644
@@ -254,7 +254,7 @@ end
     end
 
     if node.engineyard.environment.ruby?
-      template "/data/nginx/servers/#{app.name}.ssl.conf" do
+      managed_template "/data/nginx/servers/#{app.name}.ssl.conf" do
         owner node['owner_name']
         group node['owner_name']
         mode 0644
@@ -315,7 +315,7 @@ end
 
 
 
-    template "/data/nginx/ssl/#{app.name}/#{app.name}.key" do
+    managed_template "/data/nginx/ssl/#{app.name}/#{app.name}.key" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644
@@ -327,7 +327,7 @@ end
       notifies node['nginx'][:action], resources(:service => "nginx"), :delayed
     end
 
-    template "/data/nginx/ssl/#{app.name}/#{app.name}.crt" do
+    managed_template "/data/nginx/ssl/#{app.name}/#{app.name}.crt" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644
@@ -341,7 +341,7 @@ end
     end
   end
     # Add Cipher chain
-    template "/data/nginx/servers/#{app.name}/default.ssl_cipher" do
+    managed_template "/data/nginx/servers/#{app.name}/default.ssl_cipher" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644
@@ -357,7 +357,7 @@ end
     # Chain files are create if missing and do not reload Nginx
 
     # Add Cipher chain
-    template "/data/nginx/servers/#{app.name}/customer.ssl_cipher" do
+    managed_template "/data/nginx/servers/#{app.name}/customer.ssl_cipher" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644
@@ -369,7 +369,7 @@ end
     end
 
     # Add Cipher chain
-    template "/data/nginx/servers/#{app.name}/ssl_cipher" do
+    managed_template "/data/nginx/servers/#{app.name}/ssl_cipher" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644
@@ -380,7 +380,7 @@ end
       )
     end
 
-    template "/data/nginx/ssl/#{app.name}/#{app.name}.pem" do
+    managed_template "/data/nginx/ssl/#{app.name}/#{app.name}.pem" do
       owner node['owner_name']
       group node['owner_name']
       mode 0644


### PR DESCRIPTION
### Description of your patch

Fixes the keep files so chef won't attempt to overwrite certain nginx files

### Recommended Release Notes

Chef will respect known keep files for nginx

### Estimated risk

Low risk - Keep files are secondary to chef .

### Components involved
nginx

### Dependencies
nginx

### Description of testing done

Added instance to set up that was already running
### QA Instructions

Create keep files from the list provided in https://support.cloud.engineyard.com/hc/en-us/articles/205407378-Use-Keep-Files-to-Customize-and-Maintain-Configurations
Modify the values of each file once the keep file has been made
Press apply
Check the values where kept