### PR TITLE
The postgres-packages for Ubuntu 18 (release-name: bionic) have been moved to apt-archive

### DIFF
--- a/cookbooks/postgresql/files/default/pgdg.list
+++ b/cookbooks/postgresql/files/default/pgdg.list
@@ -1,2 +1,2 @@
-deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
+deb https://apt-archive.postgresql.org/pub/repos/apt bionic-pgdg main
 deb https://apt-archive.postgresql.org/pub/repos/apt bionic-pgdg-archive main


### PR DESCRIPTION
Since the packages have moved we need to adapt the sources for beeing able to "apt update"